### PR TITLE
feat: case-insensitive package aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     uses: ./.github/workflows/index.yml
     secrets: inherit
     with:
-      index-repo: ${{ needs.config.outputs.update-index == 'true' && needs.config.outputs.index-repo || '' }}
+      index-repo: ${{ needs.config.outputs.index-repo }}
       update-index: ${{ needs.config.outputs.update-index == 'true' }}
   testbed:
     needs: [config, index]

--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -59,7 +59,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RESERVOIR_INDEX_TOKEN }}
       - name: Query Repositories
         run: |
-          scripts/index-query.py -v -D index \
+          scripts/index-query.py -v -D index -R \
             -L ${{ inputs.update-index && -1 || 100 }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
 
   configure_logging(args.verbosity)
 
-  pkgs = load_index(args.index, include_builds=True)
+  pkgs, aliases = load_index(args.index, include_builds=True)
   fullPkgs: 'dict[str, any]' = dict()
   for pkg in pkgs:
     fullPkgs[pkg['fullName']] = pkg
@@ -34,7 +34,8 @@ if __name__ == "__main__":
   data = {
     'bundledAt': datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
     'toolchains': query_toolchain_releases(),
-    'packages': list(fullPkgs.values())
+    'packages': list(fullPkgs.values()),
+    'packageAliases': flatten_aliases(aliases),
   }
   if args.output is None:
     print(json.dumps(data, indent=2))

--- a/scripts/index-query.py
+++ b/scripts/index-query.py
@@ -223,10 +223,19 @@ if __name__ == "__main__":
       else:
         pkg = enrich_with_manifest(pkg_of_repo(repo))
         pkgMap[repo['id']] = pkg
+      if oldPkg['fullName'] != oldPkg['fullName'].lower():
+        # Ensures correct casing in index (can be removed when standardized)
+        logging.info(f"lowercase: '{oldPkg['fullName']}' -> '{oldPkg['fullName'].lower()}'")
+        old_path = os.path.join(args.index_dir, oldPkg['owner'])
+        new_path = os.path.join(args.index_dir, oldPkg['owner'].lower())
+        if os.path.exists(old_path): os.rename(old_path, new_path)
+        old_path = os.path.join(new_path, oldPkg['name'])
+        new_path = os.path.join(new_path, oldPkg['name'].lower())
+        if os.path.exists(old_path):  os.rename(old_path, new_path)
       if oldPkg['fullName'].lower() != pkg['fullName'].lower():
-        old_path = os.path.join(args.index_dir, oldPkg['owner'], oldPkg['name'])
+        old_path = os.path.join(args.index_dir, oldPkg['owner'].lower(), oldPkg['name'].lower())
         if os.path.isdir(old_path):
-          new_path = os.path.join(args.index_dir, pkg['owner'], pkg['name'])
+          new_path = os.path.join(args.index_dir, pkg['owner'].lower(), pkg['name'].lower())
           if os.path.isdir(new_path):
             logging.info(f"merge: '{oldPkg['fullName']}' -> '{pkg['fullName']}'")
             oldBuilds = load_builds(os.path.join(old_path, 'builds.json'))
@@ -240,13 +249,14 @@ if __name__ == "__main__":
             if os.path.isfile(new_path): os.remove(new_path)
             os.rename(old_path, new_path)
         with open(old_path, 'w') as f:
-          f.write(pkg['fullName'])
+          f.write(pkg['fullName'].lower())
       if repo['nameWithOwner'].lower() != pkg['fullName'].lower():
-        repo_path = os.path.join(args.index_dir, *repo['nameWithOwner'].split('/'))
+        owner, name = repo['nameWithOwner'].split('/')
+        repo_path = os.path.join(args.index_dir, owner.lower(), name.lower())
         if not os.path.exists(repo_path):
           logging.info(f"alias: '{repo['nameWithOwner']}' -> '{pkg['fullName']}'")
           with open(repo_path, 'w') as f:
-            f.write(pkg['fullName'])
+            f.write(pkg['fullName'].lower())
 
   limit = (0 if args.refresh else 100) if args.limit is None else args.limit
   if limit != 0:
@@ -278,7 +288,7 @@ if __name__ == "__main__":
 
   if args.index_dir is not None:
     for pkg in pkgs:
-      pkg_dir = os.path.join(args.index_dir, pkg['owner'], pkg['name'])
+      pkg_dir = os.path.join(args.index_dir, pkg['owner'].lower(), pkg['name'].lower())
       os.makedirs(pkg_dir, exist_ok=True)
       with open(os.path.join(pkg_dir, "metadata.json"), 'w') as f:
         json.dump(pkg, f, indent=2)

--- a/scripts/index-query.py
+++ b/scripts/index-query.py
@@ -212,32 +212,34 @@ if __name__ == "__main__":
       pkg['fullName'] = f"{pkg['owner']}/{name}"
     return pkg
 
-  pkgMap = dict()
+  pkg_map = dict()
   if args.index_dir is not None and args.refresh:
-    oldPkgs, _ = load_index(args.index_dir)
-    logging.info(f"found {len(oldPkgs)} existing packages")
-    repoIds = map(lambda pkg: github_repo(pkg)['id'], oldPkgs)
-    for (oldPkg, repo) in zip(oldPkgs, query_repo_data(repoIds)):
-      if repo['id'] in pkgMap:
-        pkg = pkgMap[repo['id']]
+    old_pkgs, aliases = load_index(args.index_dir)
+    logging.info(f"found {len(old_pkgs)} existing packages")
+    repo_ids = map(lambda pkg: github_repo(pkg)['id'], old_pkgs)
+    for (oldPkg, repo) in zip(old_pkgs, query_repo_data(repo_ids)):
+      if repo['id'] in pkg_map:
+        pkg = pkg_map[repo['id']]
       else:
         pkg = enrich_with_manifest(pkg_of_repo(repo))
-        pkgMap[repo['id']] = pkg
-      if oldPkg['fullName'] != oldPkg['fullName'].lower():
+        pkg_map[repo['id']] = pkg
+      old_pathname = oldPkg['fullName'].lower()
+      new_pathname = pkg['fullName'].lower()
+      if oldPkg['fullName'] != old_pathname:
         # Ensures correct casing in index (can be removed when standardized)
-        logging.info(f"lowercase: '{oldPkg['fullName']}' -> '{oldPkg['fullName'].lower()}'")
+        logging.info(f"lowercase: '{oldPkg['fullName']}' -> '{new_pathname}'")
         old_path = os.path.join(args.index_dir, oldPkg['owner'])
         new_path = os.path.join(args.index_dir, oldPkg['owner'].lower())
         if os.path.exists(old_path): os.rename(old_path, new_path)
         old_path = os.path.join(new_path, oldPkg['name'])
         new_path = os.path.join(new_path, oldPkg['name'].lower())
         if os.path.exists(old_path):  os.rename(old_path, new_path)
-      if oldPkg['fullName'].lower() != pkg['fullName'].lower():
+      if old_pathname != new_pathname:
         old_path = os.path.join(args.index_dir, oldPkg['owner'].lower(), oldPkg['name'].lower())
         if os.path.isdir(old_path):
           new_path = os.path.join(args.index_dir, pkg['owner'].lower(), pkg['name'].lower())
           if os.path.isdir(new_path):
-            logging.info(f"merge: '{oldPkg['fullName']}' -> '{pkg['fullName']}'")
+            logging.info(f"merge: '{old_pathname}' -> '{new_pathname}'")
             oldBuilds = load_builds(os.path.join(old_path, 'builds.json'))
             newBuilds = load_builds(os.path.join(new_path, 'builds.json'))
             builds = insert_build_results(oldBuilds, newBuilds)
@@ -245,54 +247,70 @@ if __name__ == "__main__":
               json.dump(builds, f, indent=2)
             shutil.rmtree(old_path)
           else:
-            logging.info(f"rename: '{oldPkg['fullName']}' -> '{pkg['fullName']}'")
-            if os.path.isfile(new_path): os.remove(new_path)
+            logging.info(f"rename: '{old_pathname}' -> '{new_pathname}'")
+            if os.path.isfile(new_path):
+              os.remove(new_path)
+              del aliases[new_pathname]
             os.rename(old_path, new_path)
-        with open(old_path, 'w') as f:
-          f.write(pkg['fullName'].lower())
-      if repo['nameWithOwner'].lower() != pkg['fullName'].lower():
+        aliases[old_pathname] = new_pathname
+      alias = repo['nameWithOwner'].lower()
+      if alias not in aliases and alias != new_pathname:
         owner, name = repo['nameWithOwner'].split('/')
         repo_path = os.path.join(args.index_dir, owner.lower(), name.lower())
         if not os.path.exists(repo_path):
-          logging.info(f"alias: '{repo['nameWithOwner']}' -> '{pkg['fullName']}'")
-          with open(repo_path, 'w') as f:
-            f.write(pkg['fullName'].lower())
+          logging.info(f"alias: '{alias}' -> '{new_pathname}'")
+          aliases[alias] = new_pathname
+  else:
+    aliases = dict()
 
   limit = (0 if args.refresh else 100) if args.limit is None else args.limit
   if limit != 0:
-    repoIds = query_lake_repos(limit)
-    logging.info(f"found {len(repoIds)} candidate repositories with root lakefiles")
-    repos = query_repo_data(repoIds)
-    if len(pkgMap) != 0:
+    repo_ids = query_lake_repos(limit)
+    logging.info(f"found {len(repo_ids)} candidate repositories with root lakefiles")
+    repos = query_repo_data(repo_ids)
+    if len(pkg_map) != 0:
       repoMap = dict([repo['id'], repo] for repo in repos)
-      newIds = set(repoMap.keys()).difference(pkgMap.keys())
+      newIds = set(repoMap.keys()).difference(pkg_map.keys())
       repos = list(map(repoMap.get, newIds))
       logging.info(f"{len(repos)} candidate repositories not in index")
     newPkgs = list(map(enrich_with_manifest, filter(curate, map(pkg_of_repo, repos))))
-    note = 'notable new' if len(pkgMap) != 0 else 'notable'
+    note = 'notable new' if len(pkg_map) != 0 else 'notable'
     logging.info(f"found {len(newPkgs)} {note} OSI-licensed packages")
   else:
     newPkgs = list()
 
-  pkgs = itertools.chain(pkgMap.values(), newPkgs)
+  pkgs = itertools.chain(pkg_map.values(), newPkgs)
   pkgs = list(sorted(pkgs, key=lambda pkg: pkg['stars'], reverse=True))
-  if len(pkgMap) != 0:
+  if len(pkg_map) != 0:
     logging.info(f"indexed {len(pkgs)} total packages")
 
   if args.output_manifest is not None:
     with open(args.output_manifest, 'w') as f:
       json.dump(pkgs, f, indent=2)
 
-  if len(pkgs) == 0:
-    exit(0)
-
   if args.index_dir is not None:
     for pkg in pkgs:
       pkg_dir = os.path.join(args.index_dir, pkg['owner'].lower(), pkg['name'].lower())
+      if os.path.isfile(pkg_dir):
+        os.remove(pkg_dir)
+        alias = f"{pkg['owner'].lower()}/{pkg['name'].lower()}"
+        del aliases[alias]
       os.makedirs(pkg_dir, exist_ok=True)
       with open(os.path.join(pkg_dir, "metadata.json"), 'w') as f:
         json.dump(pkg, f, indent=2)
         f.write("\n")
+    flatten_aliases(aliases)
+    for alias, target in aliases.items():
+      owner, name = alias.split('/')
+      owner_dir = os.path.join(args.index_dir, owner)
+      alias_path = os.path.join(owner_dir, name)
+      if os.path.isdir(alias_path):
+        logging.warning(f"package located at '{alias}': could not write alias '{alias}' -> '{target}'")
+      else:
+        os.makedirs(owner_dir, exist_ok=True)
+        with open(alias_path, 'w') as f:
+          f.write(target)
+          f.write("\n")
 
   if args.output_manifest is not None:
     with open(args.output_manifest, 'w') as f:

--- a/scripts/testbed-create.py
+++ b/scripts/testbed-create.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
   exclusions = set()
   for file in args.exclusions:
     with open(file, 'r') as f:
-      for line in f: exclusions.add(line.strip())
+      for line in f: exclusions.add(line.strip().lower())
 
   toolchains = resolve_toolchains(args.toolchain)
   def create_entries(pkgs: 'list[dict[str, any]]'):
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         }
 
   pkgs, _ = load_index(args.index)
-  pkgs = filter(lambda pkg: pkg['fullName'] not in exclusions, pkgs)
+  pkgs = filter(lambda pkg: pkg['fullName'].lower() not in exclusions, pkgs)
   if args.regex is not None:
     r = re.compile(args.regex)
     pkgs = filter(lambda pkg: r.search(pkg['fullName']) is not None, pkgs)

--- a/scripts/testbed-create.py
+++ b/scripts/testbed-create.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
           'toolchain': toolchain
         }
 
-  pkgs = load_index(args.index)
+  pkgs, _ = load_index(args.index)
   pkgs = filter(lambda pkg: pkg['fullName'] not in exclusions, pkgs)
   if args.regex is not None:
     r = re.compile(args.regex)

--- a/scripts/testbed-dev-exclusions.txt
+++ b/scripts/testbed-dev-exclusions.txt
@@ -1,10 +1,9 @@
-leanprover-community/mathlib4
-leanprover-community/sphere-eversion
+leanprover-community/mathlib
+leanprover-community/SphereEversion
 semorrison/lean-training-data
-lecopivo/SciLean
-ufmg-smite/lean-smt
-siddhartha-gadgil/LeanAide
+lecopivo/scilean
+ufmg-smite/smt
+siddhartha-gadgil/leanaide
 mo271/formal_book
 lean-dojo/LeanCopilot
-lean-dojo/LeanInfer
 lurk-lab/yatima

--- a/site/functions/package.ts
+++ b/site/functions/package.ts
@@ -5,7 +5,7 @@ export default async (req: Request, context: Context) => {
   if (!owner || !name) {
     return new Response(null, {status: 404})
   }
-  const path = `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`
+  const path = `${encodeURIComponent(owner.toLowerCase())}/${encodeURIComponent(name.toLowerCase())}`
   const fileUrl = `${new URL(req.url).origin}/index/${path}/metadata.json`
   console.log(`fetch ${fileUrl}`)
   const res = await fetch(fileUrl)

--- a/site/functions/package.ts
+++ b/site/functions/package.ts
@@ -1,17 +1,21 @@
 import { type Config, type Context } from "@netlify/functions"
 
-export default async (_req: Request, context: Context) => {
+export default async (req: Request, context: Context) => {
   const {owner, name} = context.params
   if (!owner || !name) {
     return new Response(null, {status: 404})
   }
   const path = `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`
-  const fileUrl = `${context.site.url}/index/${path}/metadata.json`
+  const fileUrl = `${new URL(req.url).origin}/index/${path}/metadata.json`
   console.log(`fetch ${fileUrl}`)
   const res = await fetch(fileUrl)
-  return new Response(res.body, {
-    headers: {"content-type": "text/event-stream"}
-  })
+  if (res.status == 200) {
+    return new Response(res.body, {
+      headers: {"Content-Type": "text/event-stream"}
+    })
+  } else {
+    return new Response(null, {status: res.status})
+  }
 };
 
 export const config: Config = {

--- a/site/modules/redirects/index.ts
+++ b/site/modules/redirects/index.ts
@@ -1,13 +1,42 @@
-import { defineRedirectsModule } from './module'
-import { type Package, packages, pkgLink } from '../../utils/manifest'
+import { type Redirect, defineRedirectsModule } from './module'
+import { packages, packageAliases, rawPkgLink } from '../../utils/manifest'
 
-const oldPkgLink = (pkg: Package) => {
-  const id = pkg['fullName'].replace('-', '--').replace('/', '-')
+function oldPkgLink(pkgName: string) {
+  const id = pkgName.replace('-', '--').replace('/', '-')
   return `/packages/${encodeURIComponent(id)}`
 }
 
-export default defineRedirectsModule(packages.map(pkg => ({
-  from: oldPkgLink(pkg),
-  to: pkgLink(pkg),
-  status: 301,
-})))
+function indexLink(owner: string, name: string, splat: string) {
+  return `/index/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/${splat}`
+}
+
+let redirects: Redirect[] = []
+for (const pkg of packages) {
+  redirects.push({
+    from: oldPkgLink(pkg.fullName),
+    to: rawPkgLink(pkg.owner, pkg.name),
+    status: 301,
+  })
+}
+for (const [alias, target] of packageAliases.entries()) {
+  const [aliasOwner, aliasName] = alias.split('/')
+  const [targetOwner, targetName] = target.split('/')
+  redirects.push({
+    from: rawPkgLink(aliasOwner, aliasName),
+    to: rawPkgLink(targetOwner, targetName),
+    status: 301,
+  })
+  redirects.push({
+    from: oldPkgLink(alias),
+    to: rawPkgLink(targetOwner, targetName),
+    status: 301,
+  })
+  redirects.push({
+    from: indexLink(aliasOwner, aliasName, '*'),
+    to: indexLink(targetOwner, targetName, ':splat'),
+    status: 301,
+    force: true,
+  })
+}
+
+export default defineRedirectsModule(redirects)

--- a/site/modules/redirects/module.ts
+++ b/site/modules/redirects/module.ts
@@ -57,8 +57,8 @@ export const createRedirectContent = (redirect: Redirect) => {
 
   // query params
   if (redirect.query && !isEmptyObject(redirect.query)) {
-    content += Object.keys(redirect.query)
-      .map(k => `${k}=${redirect.query[k]}`)
+    content += Object.entries(redirect.query)
+      .map(([k,v]) => `${k}=${v}`)
       .join('  ')
     content += divider
   }
@@ -74,8 +74,8 @@ export const createRedirectContent = (redirect: Redirect) => {
   // conditions
   if (redirect.conditions && !isEmptyObject(redirect.conditions)) {
     content += divider
-    content += Object.keys(redirect.conditions)
-      .map(k => `${k}=${redirect.conditions[k].join(',')}`)
+    content += Object.entries(redirect.conditions)
+      .map(([k,vs]) => `${k}=${vs.join(',')}`)
       .join('  ')
   }
   return `${content}\n`

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -43,8 +43,13 @@ export interface Package {
 }
 
 export const packages = manifest.packages as Package[]
+export const packageAliases = new Map<string, string>(Object.entries(manifest.packageAliases))
 export const latestToolchain: string = manifest.toolchains[0]
 
-export const pkgLink = (pkg: Package) => {
-  return `/@${encodeURIComponent(pkg.owner)}/${encodeURIComponent(pkg.name)}`
+export function rawPkgLink(owner: string, name: string) {
+  return `/@${encodeURIComponent(owner)}/${encodeURIComponent(name)}`
+}
+
+export function pkgLink(pkg: Package) {
+  return rawPkgLink(pkg.owner, pkg.name)
 }


### PR DESCRIPTION
Packages can now have multiple aliases which redirect to the package's canonical name. 

If a package has a `lake-manifest.json`, the package's canonical name is the `name` listed in the manifest. Otherwise, Reservoir falls back to the name of the GitHub repository it is sourced from, Aliases are represented in the by a file (rather than a directory) containing the canonical path to the package.

The path of the package in the index is now case-insensitive. Only the metadata of a package preserves the casing of a package's full name. This is done to make the index compatible with case-insensitive file systems. This means the index can no longer contain multiple packages with names that only differ in casing.

During an update (or CI), Reservoir will refresh all previously indexed packages and move them to their proper canonical path, creating aliases along the way. If there is already a package at the new name (e.g., because they were both indexed before this change), Reservoir will merge the packages into one (with the canonically named package taking precedence).

CI Keyword(s): UPDATE-INDEX