### PR TITLE
feat: add inclusion criteria page & require `lake-manifest.json` 

### DIFF
--- a/scripts/index-query.py
+++ b/scripts/index-query.py
@@ -74,7 +74,7 @@ def query_repo_data(repo_ids: 'Iterable[str]') -> 'list[Repo]':
 # NOTE: GitHub limits code searches to 10 requests/min, which is 1000 results.
 # Thus, the strategy used here will need to change when we hit that limit.
 def query_lake_repos(limit: int) -> 'list[str]':
-  query='filename:lakefile.lean path:/'
+  query='filename:lake-manifest.json path:/'
   if limit <= 0:
     out = capture_cmd(
       'gh', 'api', 'search/code',
@@ -286,7 +286,7 @@ if __name__ == "__main__":
   limit = (0 if args.refresh else 100) if args.limit is None else args.limit
   if limit != 0:
     repo_ids = query_lake_repos(limit)
-    logging.info(f"found {len(repo_ids)} candidate repositories with root lakefiles")
+    logging.info(f"found {len(repo_ids)} candidate repositories with root Lake manifests")
     repos = query_repo_data(repo_ids)
     if len(pkg_map) != 0:
       repoMap = dict((repo['id'], repo) for repo in repos)

--- a/site/app.vue
+++ b/site/app.vue
@@ -194,4 +194,11 @@ header {
     }
   }
 }
+
+.page-header {
+  padding: 1em;
+  background-color: var(--medium-color);
+  border-radius: 6px;
+  margin-bottom: 1em;
+}
 </style>

--- a/site/pages/inclusion-criteria.vue
+++ b/site/pages/inclusion-criteria.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="text-page">
+    <div class="page-header">
+      <h2>Inclusion Criteria</h2>
+    </div>
+    <div class="page-body">
+      <p>
+        Reservoir automatically indexes Lean repositories on GitHub.
+        To be included in its selection, a package must meet a few criteria:
+      </p>
+      <ul>
+        <li>
+          <b>Public GitHub source repository.</b>
+          Reservoir does not index forks or private repositories.
+        </li>
+        <li>
+          <b>A root <code>lake-manifest.json</code>.</b>
+          There mut be a file named exactly <code>lake-manifest.json</code>
+          in the top-level directory of the repository.
+          Prior to April 2024, Reservoir required a root <code>lakefile.lean</code> instead.
+        </li>
+        <li>
+          <b>GitHub-recognized OSI-approved license.</b>
+          GitHub displays the license it detects for a repository on the code
+          page in either the right-hand column (desktop) or in the top matter (mobile).
+          That license must then be listed as OSI-approved in the
+          <a class="hard-link" href="https://spdx.org/licenses/">SPDX License List</a>.
+        </li>
+        <li>
+          <b>At least 2 stars.</b>
+          The repository must have at least 2 stars on GitHub.
+          This serves as a very basic quality filter.
+        </li>
+      </ul>
+      <p>
+        Reservoir updates its index approximately daily.
+        If your package meets the above conditions, but does not appear on
+        Reservoir after a few days, you can report this as a bug on
+        <a class="hard-link" href="https://github.com/leanprover/reservoir/issues">Reservoir's issue tracker</a>.
+      </p>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.text-page .page-body {
+  line-height: 1.5;
+
+  p {
+    margin-bottom: 1em;
+  }
+
+  ul, ol {
+    margin-left: 2em;
+    margin-bottom: 1em;
+
+    ul, ol {
+      margin-bottom: 0;
+    }
+
+    li {
+      margin: 0.5em 0;
+    }
+  }
+
+  code {
+    font-size: 85%;
+    padding: 0.2em 0.4em;
+    background-color: var(--medium-color);
+    border-radius: 6px;
+  }
+}
+</style>

--- a/site/pages/index.vue
+++ b/site/pages/index.vue
@@ -47,9 +47,15 @@ defineOgImage({
               <span>Get Started with Lean</span>
             </a>
           </div>
-          <div class="blurb">
-            <p>Reservoir indexes, builds, and tests packages within the Lean and Lake ecosystem.</p>
-          </div>
+          <p class="blurb">
+            <span>
+              Reservoir indexes, builds, and tests packages within the Lean and Lake ecosystem.
+            </span>
+            <span>
+              If you wish to see your package here, ensure that it meets the
+              <NuxtLink class="hard-link" to="inclusion-criteria">Reservoir inclusion criteria</NuxtLink>.
+            </span>
+          </p>
         </div>
         <div class="highlights">
           <HighlightCategory title="Most Popular" :list="popular" :to="{path: '/packages', query: {sort: 'stars'}}"/>
@@ -170,6 +176,11 @@ defineOgImage({
     .blurb {
       @media only screen and (max-width: 600px) {
         text-align: center;
+      }
+
+      @media only screen and (min-width: 960px) {
+        display: flex;
+        flex-wrap: wrap;
       }
     }
   }

--- a/site/pages/packages.vue
+++ b/site/pages/packages.vue
@@ -59,9 +59,17 @@ const resultPage = computed(() => {
     </div>
     <div class="no-results" v-if="numResults === 0">
       <h3>
-        <span>0 packages found. </span>
-        <a href="https://lean-lang.org/lean4/doc/quickstart.html">Get started</a>
-        <span> to create your own!</span>
+        <p>
+          <span>0 packages found. </span>
+          <span>
+            <a class="hard-link" href="https://lean-lang.org/lean4/doc/quickstart.html">Get started</a>
+            to create your own!
+          </span>
+        </p>
+        <p>
+          Your package not here? Verify that your package meets the
+          <NuxtLink class="hard-link" to="inclusion-criteria">Reservoir inclusion criteria</NuxtLink>.
+        </p>
       </h3>
     </div>
     <div v-else class="results">
@@ -98,28 +106,17 @@ const resultPage = computed(() => {
 .search-page {
   max-width: 100vw;
 
-  .page-header {
-    padding: 1em;
-    background-color: var(--medium-color);
-    border-radius: 6px;
-    margin-bottom: 1em;
-
-    .query {
-      color: var(--dark-color);
-    }
+  .page-header .query {
+    color: var(--dark-color);
   }
 
   .no-results {
     margin-top: 2em;
 
-    a {
-      color: var(--dark-accent-color);
-
-      &:hover {
-        color: var(--light-accent-color);
-      }
+    p {
+      margin-bottom: 1em;
     }
-}
+  }
 
   .results {
     .results-header {


### PR DESCRIPTION
Adds a page describing Reservoir's inclusion criteria and links to it from the main page and from the packages page when no results are found. Also, changes the inclusion criteria to require a root `lake-manifest.json` rather than a root `lakefile.lean`.