### PR TITLE
feat: toolchain metadata & related cleanup

### DIFF
--- a/scripts/testbed-create.py
+++ b/scripts/testbed-create.py
@@ -7,29 +7,6 @@ import json
 import itertools
 import argparse
 
-NIGHTLY_REPO='leanprover/lean4-nightly'
-def resolve_toolchain(toolchain: str):
-  toolchain = toolchain.strip()
-  if len(toolchain) == 0 or toolchain == 'package':
-    return None
-  elif toolchain == 'stable':
-    releases = filter(lambda r: not r['prerelease'], query_releases())
-    return f"{DEFAULT_ORIGIN}:{next(releases)['tag']}"
-  elif toolchain == 'nightly':
-    releases = query_releases(NIGHTLY_REPO, paginate=False)
-    return f"{DEFAULT_ORIGIN}:{next(releases)['tag']}"
-  elif toolchain == 'latest':
-    releases = query_releases(paginate=False)
-    return f"{DEFAULT_ORIGIN}:{next(releases)['tag']}"
-  else:
-    return normalize_toolchain(toolchain)
-
-def resolve_toolchains(toolchains: 'list[str]') -> 'set[str | None]':
-  if len(toolchains) == 0:
-    return set([None])
-  else:
-    return set(resolve_toolchain(t) for ts in toolchains for t in ts.split(','))
-
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument('index',
@@ -52,7 +29,7 @@ if __name__ == "__main__":
       for line in f: exclusions.add(line.strip().lower())
 
   toolchains = resolve_toolchains(args.toolchain)
-  def create_entries(pkgs: 'list[dict[str, any]]'):
+  def create_entries(pkgs: 'Iterable[Package]'):
     for pkg in pkgs:
       src = next(filter(lambda src: 'gitUrl' in src, pkg['sources']))
       for toolchain in toolchains:

--- a/site/components/BuildOutcome.vue
+++ b/site/components/BuildOutcome.vue
@@ -5,7 +5,7 @@ import PassIcon from '~icons/mdi/check'
 import { Tippy } from 'vue-tippy'
 
 const props = defineProps<{build?: Build | null, markOutdated?: boolean}>()
-const build = computed<Partial<Build>>(() => props.build || {});
+const build = computed<Build | {[_ in keyof Build]?: undefined}>(() => props.build || {});
 
 const outcomeIcon = computed(() => {
   switch (build.value.outcome) {
@@ -18,7 +18,10 @@ const outcomeIcon = computed(() => {
   }
 })
 
-const outdated = computed(() => build.value.toolchain != latestToolchain);
+const outdated = computed(() => {
+  const buildToolchain = toolchains.find(t => t.name == build.value.toolchain)
+  return !buildToolchain || new Date(buildToolchain.date).getTime() < latestCutoff
+});
 
 const outcomeClass = computed(() => {
   switch (build.value.outcome) {
@@ -45,12 +48,12 @@ const outcomeClass = computed(() => {
   <template #content>
     <div class="tooltip">
       <span v-if="build.outcome == 'success'">
-        Commit {{build.revision.slice(0, 9)}} builds on
-        the {{ outdated ? 'old' : 'latest' }} {{build.toolchain}}
+        Commit {{build.revision.slice(0, 7)}} builds on
+        the {{ outdated ? 'old' : 'recent' }} {{build.toolchain}}
         <span v-if="build.requiredUpdate">after <code>lake update</code></span>
       </span>
       <span v-else-if="build.outcome == 'failure'">
-        Commit {{build.revision.slice(0, 9)}} fails to build on {{build.toolchain}}
+        Commit {{build.revision.slice(0, 7)}} fails to build on {{build.toolchain}}
       </span>
       <span v-else>
         <span class="line">Build data not currently included on Reservoir. </span>

--- a/site/components/HighlightCategory.vue
+++ b/site/components/HighlightCategory.vue
@@ -5,7 +5,7 @@ import type { RouteLocationRaw } from 'vue-router'
 const props = defineProps<{title: string, list: Package[], to: RouteLocationRaw}>()
 const findBuild = (pkg: Package) => (
   pkg.builds.find(b => b.outcome == "success") ??
-  pkg.builds.find(b => b.toolchain === latestToolchain) ??
+  pkg.builds.find(b => b.toolchain === latestToolchain.name) ??
   pkg.builds[0]
 )
 </script>

--- a/site/components/PackageResult.vue
+++ b/site/components/PackageResult.vue
@@ -5,7 +5,7 @@ const pkg = computed(() => props.pkg)
 const src = computed(() => pkg.value.sources.find(src => src.repoUrl))
 const build = computed(() =>
   pkg.value.builds.find(b => b.outcome == "success") ??
-  pkg.value.builds.find(b => b.toolchain === latestToolchain)
+  pkg.value.builds.find(b => b.toolchain === latestToolchain.name)
 )
 </script>
 

--- a/site/pages/@[owner]/[name].vue
+++ b/site/pages/@[owner]/[name].vue
@@ -57,17 +57,17 @@ const formatLicense = (id: string | null) => {
   }
 }
 
-const buildsByVer = computed(() => {
+const toolchainBuilds = computed(() => {
   const map = pkg.builds.reduce((map, build) => {
     if (!map.has(build.toolchain)) {
       map.set(build.toolchain, build)
     }
     return map;
   }, new Map<string, Build | null>())
-  if (!map.has(latestToolchain)) {
-    map.set(latestToolchain, null)
+  if (!map.has(latestToolchain.name)) {
+    map.set(latestToolchain.name, null)
   }
-  return map
+  return Array(...map.entries())
 })
 
 const baseContentUrl = computed(() => {
@@ -113,9 +113,9 @@ const {data: readme} = await useFetch<string>(readmeUrl)
         <div>
           <h3>Lean</h3>
           <ul>
-            <li v-for="entry in buildsByVer.entries()">
-              <BuildOutcome class="icon" :build="entry[1]"/>
-              {{ entry[0].split(':')[1] }}
+            <li v-for="[toolchain, build] in toolchainBuilds">
+              <BuildOutcome class="icon" :build="build"/>
+              {{ toolchain.split(':')[1] }}
             </li>
           </ul>
         </div>
@@ -176,6 +176,7 @@ const {data: readme} = await useFetch<string>(readmeUrl)
 
       aside {
         max-width: 15em;
+        flex: 0 0 auto;
       }
 
       .page-main {

--- a/site/pages/index.vue
+++ b/site/pages/index.vue
@@ -39,8 +39,8 @@ defineOgImage({
         <div class="intro">
           <div class="top-line">
             <div class="toolchain">
-              <h4 class="label">Latest Lean Toolchain:</h4>
-              <span class="name">{{ latestToolchain }}</span>
+              <h4 class="label">Latest Lean Stable:</h4>
+              <a :href="latestStableToolchain.releaseUrl" class="name">{{ latestStableToolchain.name }}</a>
             </div>
             <a class="get-started" href="https://lean-lang.org/lean4/doc/quickstart.html">
               <GetStartedIcon class="prefix icon"/>

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -29,7 +29,7 @@ export interface Build {
 }
 
 export interface Package {
-  name : string
+  name: string
   owner: string
   fullName: string
   description: string | null
@@ -42,9 +42,22 @@ export interface Package {
   builds: Build[]
 }
 
+export interface Toolchain {
+  name: string
+  version: number | null
+  tag: string
+  date: string
+  releaseUrl: string
+  prerelease: boolean
+}
+
 export const packages = manifest.packages as Package[]
 export const packageAliases = new Map<string, string>(Object.entries(manifest.packageAliases))
-export const latestToolchain: string = manifest.toolchains[0]
+export const toolchains = manifest.toolchains as Toolchain[]
+export const latestToolchain = toolchains[0]
+export const latestStableToolchain = toolchains.find(t => !t.prerelease) ?? latestToolchain
+export const oldestStableVerToolchain = toolchains.findLast(t => t.version == latestStableToolchain.version)
+export const latestCutoff = new Date(oldestStableVerToolchain.date).getTime()
 
 export function rawPkgLink(owner: string, name: string) {
   return `/@${encodeURIComponent(owner)}/${encodeURIComponent(name)}`


### PR DESCRIPTION
Site toolchains now carry additional metadata. This metadata is used to accomplish a few things:

* Sort toolchains by the date the release was created.
* The main page now displays the latest stable Lean toolchain, rather than simply the latest one. Clicking on the toolchain will take the user to the toolchain's release notes.
* A package is considered to have an up-to-date build (a green rather than a gold checkmark) if the package toolchain with the same or newer minor version as the latest stable release. For example, if the latest stable is `4.6.1`, a package which builds on any of `4.6.0-rc1`, `4.6.0`, `4.6.1`, or `v4.7.0-rc1` is considered up-to-date.

This also includes some general cleanup / refactoring of related code. 

Closes #12.