### PR TITLE
feat: API v1

### DIFF
--- a/site/functions/package/index.ts
+++ b/site/functions/package/index.ts
@@ -1,23 +1,49 @@
 import { type Config, type Context } from "@netlify/functions"
 
+function error(status: number, message: string, headers: HeadersInit = {}): Response {
+  return new Response(JSON.stringify({"error": {status, message}}), {
+    status, headers: {"Content-Type": "application/json; charset=utf-8", ...headers}
+  })
+}
+
 export default async (req: Request, context: Context) => {
   const {owner, name} = context.params
-  if (!owner || !name) {
-    return new Response(null, {status: 404})
+  const lakeVer = req.headers.get("X-Lake-Registry-Api-Version")
+  const reservoirVer = req.headers.get("X-Reservoir-Api-Version")
+  console.log(`${req.method} ${owner ?? ""}/${name ?? ""} Reservoir:${reservoirVer ?? "-"} Lake:${lakeVer ?? "-"}`)
+  if (req.method !== "GET") {
+    if (req.method === "HEAD") { // body not allowed
+      return new Response(null, {status: 405, headers: {'Allow': 'GET'}})
+    } else {
+      return error(405, `${req.method} not allowed; can only GET packages`, {'Allow': 'GET'})
+    }
+  }
+  if (!name) {
+    return error(400, "Ill-formed package name")
+  }
+  if (!owner) {
+    return error(400, "Ill-formed package owner")
   }
   const path = `${encodeURIComponent(owner.toLowerCase())}/${encodeURIComponent(name.toLowerCase())}`
   const fileUrl = `${new URL(req.url).origin}/index/${path}/metadata.json`
-  console.log(`fetch ${fileUrl}`)
+  console.log(`Fetch ${fileUrl}`)
   const res = await fetch(fileUrl)
   if (res.status == 200) {
     return new Response(res.body, {
-      headers: {"Content-Type": "text/event-stream"}
+      headers: {"Content-Type": "application/json; charset=utf-8"}
     })
+  } else if (res.status == 404) {
+    return error(404, `Package  '${owner}/${name}' not found in index`)
   } else {
-    return new Response(null, {status: res.status})
+    console.error(`Fetch failed with status ${res.status}`)
+    return error(500, "Failed to retrieve package data from index")
   }
 };
 
 export const config: Config = {
-  path: "/api/v0/packages/:owner/:name"
+  path: [
+    "/api/packages/:owner/:name",
+    "/api/v1/packages/:owner/:name",
+    "/api/v0/packages/:owner/:name",
+  ]
 }

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -4,6 +4,7 @@ export interface GitSource {
   type: 'git'
   gitUrl: string
   defaultBranch?: string
+  subDir?: string
 }
 
 export interface RepoSource {
@@ -56,7 +57,7 @@ export const packageAliases = new Map<string, string>(Object.entries(manifest.pa
 export const toolchains = manifest.toolchains as Toolchain[]
 export const latestToolchain = toolchains[0]
 export const latestStableToolchain = toolchains.find(t => !t.prerelease) ?? latestToolchain
-export const oldestStableVerToolchain = toolchains.findLast(t => t.version == latestStableToolchain.version)
+export const oldestStableVerToolchain = toolchains.findLast(t => t.version == latestStableToolchain.version) ?? latestToolchain
 export const latestCutoff = new Date(oldestStableVerToolchain.date).getTime()
 
 export function rawPkgLink(owner: string, name: string) {


### PR DESCRIPTION
Moves the Reservoir API to `v1` in preparation for the release of Lake integration in [lean4#4495](https://github.com/leanprover/lean4/pull/4495).

* Adds the `/api/v1/`  as the primary API endpoint. URI schema is no different from `/api/v0/`.
* Adds the base `/api/` as an alternative endpoint should we decide to switch to header-only versioning.
* Logs the `X-Reservoir-Api-Version` and `X-Lake-Registry-Api-Version` headers of requests.
* Richer responses on errors.
* Adds `subDir` as a potential field of a `GitSource`.