### PR TITLE
perf: use graphql to fetch manifests

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -32,7 +32,7 @@ on:
 
 # Permit only 1 concurrent update of the same index repository.
 concurrency:
-  group: ${{ inputs.update-index && format('index/{0}', inputs.index-repo) || github.run_id }}
+  group: ${{ inputs.update-index && format('update-index/{0}', inputs.index-repo) || format('index/{0}', github.run_id) }}
 
 jobs:
   index:
@@ -53,14 +53,12 @@ jobs:
         run: |
           set -eo pipefail
           mkdir index
-          gh api repos/${{ inputs.index-repo || 'leanprover/reservoir-index' }}/tarball \
-            | tar -xvz -C index --strip-component=1
+          gh api repos/${{inputs.index-repo}}/tarball |
+            tar -xvz -C index --strip-component=1
         env:
           GH_TOKEN: ${{ secrets.RESERVOIR_INDEX_TOKEN }}
       - name: Query Repositories
-        run: |
-          scripts/index-query.py -v -D index -R \
-            -L ${{ inputs.update-index && -1 || 100 }}
+        run: scripts/index-query.py -v -D index -R -L -1
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Update Index Repository

--- a/.github/workflows/testbed.yml
+++ b/.github/workflows/testbed.yml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     # Permit only 1 concurrent update of the same index repository.
     concurrency:
-      group: testbed/${{ inputs.index-repo }}
+      group: update-index/${{ inputs.index-repo }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,7 +44,7 @@ permissions:
   contents: read
   statuses: write
 
-# Allow only one concurrent deployment per commit or per prodcution, cancelling previous ones.
+# Allow only one concurrent deployment per commit or per production, cancelling previous ones.
 concurrency:
   group: website/${{ inputs.production-deploy && 'prod' || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Reservoir will now fetch the Lake manifest of a repository as part of the GraphQL query of the repository data. This decrease the number of GitHub requests, which should hopefully help avoid rate limits. However, it does increases the amount of the data returned data, so that may present its own problems. Local tests indicate this is not a problem, so we will see how it performs in production. 