### PR TITLE
feat: build archive metrics

### DIFF
--- a/scripts/testbed-collect.py
+++ b/scripts/testbed-collect.py
@@ -6,6 +6,14 @@ import re
 import argparse
 import os
 
+# adapted from https://stackoverflow.com/questions/1094841/get-a-human-readable-version-of-a-file-size
+def fmt_bytes(num):
+  for unit in ("", "K", "M", "G", "T", "P", "E", "Z"):
+    if abs(num) < 1000.0:
+      return f"{num:3.1f} {unit}B"
+    num /= 1000.0
+  return f"{num:.1f}YB"
+
 class Job(TypedDict):
   id: int
   name: str
@@ -76,7 +84,7 @@ if __name__ == "__main__":
       archiveSizes.append(archiveSize)
 
   avg = round(sum(archiveSizes)/len(archiveSizes))
-  logging.info(f'Average build archive size: {avg}')
+  logging.info(f'Average build archive size: {fmt_bytes(avg)} ({avg} bytes)')
 
   if args.output is None:
     print(json.dumps(results, indent=2))

--- a/scripts/testbed-collect.py
+++ b/scripts/testbed-collect.py
@@ -12,7 +12,7 @@ def fmt_bytes(num):
     if abs(num) < 1000.0:
       return f"{num:3.1f} {unit}B"
     num /= 1000.0
-  return f"{num:.1f}YB"
+  return f"{num:.1f} YB"
 
 class Job(TypedDict):
   id: int
@@ -63,6 +63,9 @@ if __name__ == "__main__":
   def find_build_job(name: str) -> Job:
     return next(job for job in jobs if is_build_job(job, name))
 
+  logging.info(f"{len(matrix)} total testbed entries")
+
+  num_results = 0
   results: 'dict[str, list[Build]]'= dict()
   archiveSizes: 'list[int]' = list()
   for entry in matrix:
@@ -78,12 +81,17 @@ if __name__ == "__main__":
       result: Build = header | json.load(f)
     if entry['fullName'] not in results:
       results[entry['fullName']] = list()
+    num_results += 1
     results[entry['fullName']].append(result)
     archiveSize = result.get('archiveSize', None)
     if archiveSize is not None:
       archiveSizes.append(archiveSize)
 
-  avg = round(sum(archiveSizes)/len(archiveSizes))
+  logging.info(f"{len(results)} testbed entries with results")
+
+  num_archives = len(archiveSizes)
+  avg = round(sum(archiveSizes)/num_archives)
+  logging.info(f"{num_archives} testbed entries with archives")
   logging.info(f'Average build archive size: {fmt_bytes(avg)} ({avg} bytes)')
 
   if args.output is None:

--- a/scripts/testbed-dev-exclusions.txt
+++ b/scripts/testbed-dev-exclusions.txt
@@ -1,5 +1,6 @@
 leanprover-community/mathlib
 leanprover-community/SphereEversion
+ImperialCollegeLondon/FLT
 semorrison/lean-training-data
 lecopivo/scilean
 ufmg-smite/smt

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -27,13 +27,25 @@ class Source(TypedDict):
   gitUrl: str
   defaultBranch: str
 
-class Build(TypedDict):
+class RunHeader(TypedDict):
   url: str
   builtAt: str
+
+class BuildBase(RunHeader):
+  revision: str
+  toolchain: str
+  outcome: str
+
+class Build(BuildBase, total=False):
+  requiredUpdate: bool
+  archiveSize: int | None
+
+class PartialBuild(TypedDict, total=False):
   revision: str
   toolchain: str
   requiredUpdate: bool
   outcome: str
+  archiveSize: int | None
 
 class PackageBase(TypedDict):
   name: str


### PR DESCRIPTION
Runs `lake pack` as part of the testbed and stores the archive size as part of the index. At the end of the testbed, logs the number of packed archives and average archive size for the testbed.