### PR TITLE
refactor: use index GitHub token for querying

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Query Repositories
         run: scripts/index-query.py -v -D index -R -L -1
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RESERVOIR_INDEX_TOKEN }}
       - name: Update Index Repository
         if: inputs.index-repo && inputs.update-index
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
Use the `RESERVOIR_INDEX_TOKEN` to authenticate repository search. GitHub Support indicating that the reason for the frequent secondary rate limit failure is too many parallel queries to the `search/code` endpoint from the default workflow GitHub token whose actor (the GitHub bot) is shared across GitHub.