### PR TITLE
refactor: package toolchain list

### DIFF
--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -21,10 +21,9 @@ if __name__ == "__main__":
   configure_logging(args.verbosity)
 
   toolchains = query_toolchains()
-  toolchainDates = dict((t['name'], of_utc_iso(t['date'])) for t in toolchains)
-  min_utc = datetime.min.replace(tzinfo=timezone.utc)
-  def toolchain_date(build: Build) -> datetime:
-    return toolchainDates.get(build['toolchain'], min_utc)
+  toolchain_sort_keys = dict((t['name'], toolchain_sort_key(t)) for t in toolchains)
+  def build_sort_key(build: Build):
+    return toolchain_sort_keys.get(build['toolchain'], MIN_TOOLCHAIN_SORT_KEY)
 
   pkgs, aliases = load_index(args.index, include_builds=True)
   pkgMap = dict((pkg['fullName'], pkg) for pkg in pkgs)
@@ -35,7 +34,7 @@ if __name__ == "__main__":
       pkg = pkgMap[full_name]
       pkg['builds'] = insert_build_results(pkg['builds'], pkg_results)
   for pkg in pkgMap.values():
-    pkg['builds'] = sorted(pkg['builds'], key=toolchain_date, reverse=True)
+    pkg['builds'] = sorted(pkg['builds'], key=build_sort_key, reverse=True)
 
   data = {
     'bundledAt': utc_iso_now(),

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -197,6 +197,11 @@ def utc_iso_now():
 def of_utc_iso(iso: str) -> datetime:
   return datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
 
+def toolchain_sort_key(t: Toolchain):
+    return (t['version'] or 0, of_utc_iso(t['date']))
+
+MIN_TOOLCHAIN_SORT_KEY = (0, datetime.min.replace(tzinfo=timezone.utc))
+
 TOOLCHAIN_VER_PATTERN = re.compile("v4\\.(\\d+)\\..*")
 def query_toolchains(repo=DEFAULT_ORIGIN) -> 'list[Toolchain]':
   def toolchain_of_release(rel: Release) -> Toolchain:
@@ -211,7 +216,7 @@ def query_toolchains(repo=DEFAULT_ORIGIN) -> 'list[Toolchain]':
       "prerelease": rel['prerelease']
     }
   toolchains = map(toolchain_of_release, query_releases(repo))
-  return sorted(toolchains, key=lambda t: of_utc_iso(t['date']), reverse=True)
+  return sorted(toolchains, key=toolchain_sort_key, reverse=True)
 
 def normalize_toolchain(toolchain: str):
   parts = toolchain.split(':')

--- a/site/app.vue
+++ b/site/app.vue
@@ -62,6 +62,7 @@ h1, * {
 a {
   color: inherit;
   text-decoration: none;
+  cursor: pointer;
 
   &.soft-link {
     &:hover, &:focus {

--- a/site/pages/@[owner]/[name].vue
+++ b/site/pages/@[owner]/[name].vue
@@ -57,7 +57,8 @@ const formatLicense = (id: string | null) => {
   }
 }
 
-const toolchainBuilds = computed(() => {
+type ToolchainBuild = [string, Build | null]
+const allToolchainBuilds = computed<ToolchainBuild[]>(() => {
   const map = pkg.builds.reduce((map, build) => {
     if (!map.has(build.toolchain)) {
       map.set(build.toolchain, build)
@@ -69,6 +70,11 @@ const toolchainBuilds = computed(() => {
     entries.unshift([latestToolchain.name, null])
   }
   return entries
+})
+const shortBuildLimit = 10
+const shortBuildToggle = ref(allToolchainBuilds.value.length > shortBuildLimit)
+const toolchainBuilds = computed<ToolchainBuild[]>(() => {
+  return allToolchainBuilds.value.slice(0, shortBuildToggle.value ? shortBuildLimit : undefined)
 })
 
 const baseContentUrl = computed(() => {
@@ -117,6 +123,11 @@ const {data: readme} = await useFetch<string>(readmeUrl)
             <li v-for="[toolchain, build] in toolchainBuilds">
               <BuildOutcome class="icon" :build="build"/>
               {{ toolchain.split(':')[1] }}
+            </li>
+            <li v-if="shortBuildToggle" @click="shortBuildToggle = false" >
+              <a class="hard-link" tabindex="0" @keyup.enter="shortBuildToggle = false">
+                + {{ allToolchainBuilds.length - shortBuildLimit }} more
+              </a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
* Toolchains are now sorted first by minor version and then by date.
* Package toolchain builds are initially limited to the latest 10 toolchains with a "+ more" toggle to show the full list.