### PR TITLE
feat: redirect package to name w/ canonical casing

### DIFF
--- a/site/modules/redirects/index.ts
+++ b/site/modules/redirects/index.ts
@@ -1,5 +1,5 @@
 import { type Redirect, defineRedirectsModule } from './module'
-import { packages, packageAliases, rawPkgLink } from '../../utils/manifest'
+import { packages, packageAliases, rawPkgLink, pkgLink, findPkg } from '../../utils/manifest'
 
 function oldPkgLink(pkgName: string) {
   const id = pkgName.replace('-', '--').replace('/', '-')
@@ -21,14 +21,15 @@ for (const pkg of packages) {
 for (const [alias, target] of packageAliases.entries()) {
   const [aliasOwner, aliasName] = alias.split('/')
   const [targetOwner, targetName] = target.split('/')
+  const targetPkg = findPkg(targetOwner, targetName)!
   redirects.push({
     from: rawPkgLink(aliasOwner, aliasName),
-    to: rawPkgLink(targetOwner, targetName),
+    to: pkgLink(targetPkg),
     status: 301,
   })
   redirects.push({
     from: oldPkgLink(alias),
-    to: rawPkgLink(targetOwner, targetName),
+    to: pkgLink(targetPkg),
     status: 301,
   })
   redirects.push({

--- a/site/pages/@[owner]/[name].vue
+++ b/site/pages/@[owner]/[name].vue
@@ -6,13 +6,22 @@ import HomepageIcon from '~icons/mdi/home'
 import GitHubIcon from '~icons/mdi/github'
 
 const route = useRoute()
-const pkg = packages.find(p => p.owner === route.params.owner && p.name == route.params.name)
-if (!pkg) {
+const owner = route.params.owner as string
+const name = route.params.name as string
+const maybePkg = packages.find(p => {
+  return p.owner.toLowerCase() === owner.toLowerCase() &&
+    p.name.toLowerCase() == name.toLowerCase()
+})
+if (maybePkg === undefined) {
   throw createError({
     statusCode: 404,
-    message: `Package ${route.params.fullName} not found`,
+    statusMessage: `Package '${owner}/${name}' not found`,
     fatal: true
   })
+}
+const pkg: Package = maybePkg
+if (pkg.owner !== owner || pkg.name !== name) {
+  navigateTo(pkgLink(pkg), {replace: true})
 }
 
 useHead({

--- a/site/pages/@[owner]/[name].vue
+++ b/site/pages/@[owner]/[name].vue
@@ -8,10 +8,7 @@ import GitHubIcon from '~icons/mdi/github'
 const route = useRoute()
 const owner = route.params.owner as string
 const name = route.params.name as string
-const maybePkg = packages.find(p => {
-  return p.owner.toLowerCase() === owner.toLowerCase() &&
-    p.name.toLowerCase() == name.toLowerCase()
-})
+const maybePkg = findPkg(owner, name)!
 if (maybePkg === undefined) {
   throw createError({
     statusCode: 404,

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -60,6 +60,13 @@ export const latestStableToolchain = toolchains.find(t => !t.prerelease) ?? late
 export const oldestStableVerToolchain = toolchains.findLast(t => t.version == latestStableToolchain.version) ?? latestToolchain
 export const latestCutoff = new Date(oldestStableVerToolchain.date).getTime()
 
+export function findPkg(owner: string, name: string) {
+  return packages.find(p => {
+    return p.owner.toLowerCase() === owner.toLowerCase() &&
+      p.name.toLowerCase() == name.toLowerCase()
+  })
+}
+
 export function rawPkgLink(owner: string, name: string) {
   return `/@${encodeURIComponent(owner)}/${encodeURIComponent(name)}`
 }


### PR DESCRIPTION
Package URLs are now case insensitive. A URL with non-standard casing will direct to the canonical name. Netlify directs for aliases will also now redirect to the package's canonical casing.