### PR TITLE
feat: JSON case-preserving package aliases

### DIFF
--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from utils import *
-from datetime import datetime, timezone
 import argparse
 import json
 
@@ -40,7 +39,7 @@ if __name__ == "__main__":
     'bundledAt': utc_iso_now(),
     'toolchains': toolchains,
     'packages': list(pkgMap.values()),
-    'packageAliases': flatten_aliases(aliases),
+    'packageAliases': encode_aliases(aliases),
   }
   if args.output is None:
     print(json.dumps(data, indent=2))

--- a/site/modules/redirects/index.ts
+++ b/site/modules/redirects/index.ts
@@ -7,14 +7,14 @@ function oldPkgLink(pkgName: string) {
 }
 
 function indexLink(owner: string, name: string, splat: string) {
-  return `/index/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/${splat}`
+  return `/index/${encodeURIComponent(owner.toLowerCase())}/${encodeURIComponent(name.toLowerCase())}/${splat}`
 }
 
 let redirects: Redirect[] = []
 for (const pkg of packages) {
   redirects.push({
     from: oldPkgLink(pkg.fullName),
-    to: rawPkgLink(pkg.owner, pkg.name),
+    to: pkgLink(pkg),
     status: 301,
   })
 }


### PR DESCRIPTION
Aliases are now stored in the index as a JSON file with the following schema:

```typescript
interface AliasStub {
    alias: {from: string, to: string}
}
```

This enables the case of an alias to be preserved, which is important for Netlify redirects (as they are case-sensitive).