### PR TITLE
feat: S3 build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
       reindex: ${{ steps.compute.outputs.reindex }}
       update-index: ${{ steps.compute.outputs.update-index }}
       testbed: ${{ steps.compute.outputs.testbed }}
+      package-pattern: ${{ steps.compute.outputs.package-pattern }}
       testbed-size: ${{ steps.compute.outputs.testbed-size }}
       testbed-toolchain: ${{ steps.compute.outputs.testbed-toolchain }}
       production-deploy: ${{ steps.compute.outputs.production-deploy }}
@@ -79,9 +80,15 @@ jobs:
         name: Compute Configuration
         run: |
           if ${{ github.event_name == 'pull_request' }}; then
-            echo reindex=${{ contains(github.event.pull_request.labels.*.name, 'A-index') }} >> "$GITHUB_OUTPUT"
-            echo search-packages=${{ contains(github.event.pull_request.labels.*.name, 'A-index') }} >> "$GITHUB_OUTPUT"
-            echo testbed=${{ contains(github.event.pull_request.labels.*.name, 'A-index') || contains(github.event.pull_request.labels.*.name, 'A-testbed') }} >> "$GITHUB_OUTPUT"
+            if ${{ contains(github.event.pull_request.labels.*.name, 'A-index') }}; then
+              echo reindex=true >> "$GITHUB_OUTPUT"
+              echo search-packages=true >> "$GITHUB_OUTPUT"
+              echo testbed=true >> "$GITHUB_OUTPUT"
+              echo 'package-pattern=.*' >> "$GITHUB_OUTPUT"
+            elif ${{ contains(github.event.pull_request.labels.*.name, 'A-testbed') }}; then
+              echo testbed=true >> "$GITHUB_OUTPUT"
+              echo 'package-pattern=^leanprover' >> "$GITHUB_OUTPUT"
+            fi
             echo 'testbed-toolchain=${{ contains(github.event.pull_request.labels.*.name, 'A-testbed') && 'package,latest' || 'none' }}' >> "$GITHUB_OUTPUT"
           else
             if ${{ github.event_name == 'push' && github.ref_name == 'master' && contains(github.event.head_commit.message, 'UPDATE-INDEX') }}; then
@@ -114,7 +121,7 @@ jobs:
     with:
       index-repo: ${{ needs.config.outputs.index-repo }}
       search-packages: ${{ needs.config.outputs.search-packages == 'true' }}
-      package-pattern: ${{ needs.config.outputs.reindex == 'true' && (inputs.package-pattern || '.*') || '' }}
+      package-pattern: ${{ needs.config.outputs.package-pattern }}
       version-pattern: ${{ inputs.version-pattern }}
       toolchain: ${{ needs.config.outputs.testbed-toolchain }}
       max-size: ${{ fromJson(needs.config.outputs.testbed-size) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,18 @@ on:
         description: "Max number of testbed entries"
         type: number
         required: false
+      cache-builds:
+        description: "Upload builds to cloud cache"
+        type: boolean
+        required: false
       update-index:
         description: "Save testbed results to index"
         type: boolean
         required: false
-        default: false
       production-deploy:
         description: "Deploy website to production"
         type: boolean
         required: false
-        default: false
 
 # GITHUB_TOKEN permissions needed for deployment (copied from website.yml)
 permissions:
@@ -73,6 +75,7 @@ jobs:
       package-pattern: ${{ steps.compute.outputs.package-pattern }}
       testbed-size: ${{ steps.compute.outputs.testbed-size }}
       testbed-toolchain: ${{ steps.compute.outputs.testbed-toolchain }}
+      cache-builds: ${{ steps.compute.outputs.cache-builds  }}
       production-deploy: ${{ steps.compute.outputs.production-deploy }}
     steps:
       # We echo even simple values out to make failures easier to debug from the logs
@@ -82,14 +85,15 @@ jobs:
           if ${{ github.event_name == 'pull_request' }}; then
             if ${{ contains(github.event.pull_request.labels.*.name, 'A-index') }}; then
               echo reindex=true >> "$GITHUB_OUTPUT"
-              echo search-packages=true >> "$GITHUB_OUTPUT"
               echo testbed=true >> "$GITHUB_OUTPUT"
               echo 'package-pattern=.*' >> "$GITHUB_OUTPUT"
             elif ${{ contains(github.event.pull_request.labels.*.name, 'A-testbed') }}; then
               echo testbed=true >> "$GITHUB_OUTPUT"
               echo 'package-pattern=^leanprover' >> "$GITHUB_OUTPUT"
             fi
+            echo search-packages=${{ contains(github.event.pull_request.labels.*.name, 'A-search') }} >> "$GITHUB_OUTPUT"
             echo 'testbed-toolchain=${{ contains(github.event.pull_request.labels.*.name, 'A-testbed') && 'package,latest' || 'none' }}' >> "$GITHUB_OUTPUT"
+            echo cache-builds=${{ contains(github.event.pull_request.labels.*.name, 'A-cache') }} >> "$GITHUB_OUTPUT"
           else
             if ${{ github.event_name == 'push' && github.ref_name == 'master' && contains(github.event.head_commit.message, 'UPDATE-INDEX') }}; then
               echo reindex=true >> "$GITHUB_OUTPUT"
@@ -97,6 +101,7 @@ jobs:
               echo update-index=true >> "$GITHUB_OUTPUT"
               echo testbed=true  >> "$GITHUB_OUTPUT"
               echo testbed-toolchain=none >> "$GITHUB_OUTPUT"
+              echo cache-builds=true  >> "$GITHUB_OUTPUT"
             else
               if ${{ github.event_name != 'workflow_dispatch' }}; then
                 echo testbed=${{ github.ref_name != 'master' }} >> "$GITHUB_OUTPUT"
@@ -105,6 +110,7 @@ jobs:
               fi
               echo reindex=${{  github.event_name == 'workflow_dispatch' && !!inputs.package-pattern }} >> "$GITHUB_OUTPUT"
               echo search-packages=${{ inputs.search-packages == true }}  >> "$GITHUB_OUTPUT"
+              echo cache-builds=${{ inputs.cache-builds == true }}  >> "$GITHUB_OUTPUT"
               echo update-index=${{ inputs.update-index == true }} >> "$GITHUB_OUTPUT"
               echo 'testbed-toolchain=${{ inputs.testbed-toolchain || 'none' }}' >> "$GITHUB_OUTPUT"
             fi
@@ -125,7 +131,8 @@ jobs:
       version-pattern: ${{ inputs.version-pattern }}
       toolchain: ${{ needs.config.outputs.testbed-toolchain }}
       max-size: ${{ fromJson(needs.config.outputs.testbed-size) }}
-      update-index: ${{ inputs.update-index == true }}
+      cache-builds: ${{ needs.config.outputs.cache-builds == 'true' }}
+      update-index: ${{ needs.config.outputs.update-index == 'true' }}
       dev: ${{ github.event_name != 'workflow_dispatch' }}
   website:
     needs: [config, testbed]

--- a/.github/workflows/testbed-layer.yml
+++ b/.github/workflows/testbed-layer.yml
@@ -36,14 +36,10 @@ jobs:
       - name: Analyze
         continue-on-error: true
         # We run arbitrary untrusted code here
-        run: |
-          scripts/testbed-analyze.py -v -o result.json \
-            ${{ matrix.gitUrl }} \
-            -T '${{ matrix.toolchains }}' \
-            -V '${{ matrix.versionTags }}'
+        run: scripts/testbed-analyze.py -v -d testbed -m '${{ toJson(matrix) }}'
       - name: Upload Result
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: result.json
+          path: testbed/artifact
           if-no-files-found: warn

--- a/.github/workflows/testbed.yml
+++ b/.github/workflows/testbed.yml
@@ -166,6 +166,9 @@ jobs:
             -R '${{ github.repository }}'
         env:
           GH_TOKEN: ${{ secrets.RESERVOIR_INDEX_TOKEN }}
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
       - name: Upload Results Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/testbed.yml
+++ b/.github/workflows/testbed.yml
@@ -162,11 +162,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Download Individual Results
-        uses: actions/download-artifact@v4
-        with:
-          # Without a name, downloads all artifacts
-          path: testbed
       - name: Collect Outcomes
         run: |
           scripts/testbed-collect.py \

--- a/.github/workflows/testbed.yml
+++ b/.github/workflows/testbed.yml
@@ -42,6 +42,10 @@ on:
         description: "Max number of packages to test"
         type: number
         required: false
+      cache-builds:
+        description: "Upload builds to cloud cache"
+        type: boolean
+        required: false
       update-index:
         description: "Save to index"
         type: boolean
@@ -82,6 +86,10 @@ on:
         description: "Max number of testbed entries"
         type: number
         required: false
+      cache-builds:
+        description: "Upload builds to cloud cache"
+        type: boolean
+        required: false
       update-index:
         description: "Save to index"
         type: boolean
@@ -120,7 +128,8 @@ jobs:
             -T '${{ inputs.toolchain || 'package' }}'  \
             -n ${{ toJson(inputs.max-size) == 'null' && -1 || inputs.max-size }} \
             -Q ${{ inputs.search-packages && (inputs.dev && 100 || -1) || 0 }} \
-            -X ${{ inputs.dev && 'scripts/package-dev-exclusions.txt' || 'scripts/package-exclusions.txt' }}
+            -X ${{ inputs.dev && 'scripts/package-dev-exclusions.txt' || 'scripts/package-exclusions.txt' }} \
+            ${{ inputs.cache-builds && '--cache' || '--no-cache' }}
         env:
           GH_TOKEN: ${{ secrets.RESERVOIR_INDEX_TOKEN }}
       - name: Upload Matrix
@@ -160,7 +169,8 @@ jobs:
           path: testbed
       - name: Collect Outcomes
         run: |
-          scripts/testbed-collect.py -v \
+          scripts/testbed-collect.py \
+            ${{ inputs.update-index && '--prod-cache' || '' }} \
             testbed -o testbed/results.json \
             ${{ github.run_id }} ${{ github.run_attempt }} \
             -R '${{ github.repository }}'

--- a/scripts/testbed-analyze.py
+++ b/scripts/testbed-analyze.py
@@ -344,7 +344,7 @@ if __name__ == "__main__":
     if args.matrix is not None:
       entry: TestbedEntry = json.loads(args.matrix)
       url = entry['gitUrl']
-      target_toolchains = resolve_toolchains(entry['toolchains'])
+      target_toolchains = resolve_toolchains([entry['toolchains']])
       version_tags = entry['versionTags']
       cache_builds = entry['cacheBuilds']
     else:

--- a/scripts/testbed-analyze.py
+++ b/scripts/testbed-analyze.py
@@ -30,7 +30,12 @@ def has_mathlib(deps: list[Dependency] | None):
   else:
     return any(dep.get('name', None) == 'mathlib' for dep in deps)
 
-def try_build(ver: PackageVersion, target_toolchain: str | None, is_mathlib=False) -> tuple[BuildResult | None, bool]:
+def try_build(
+    ver: PackageVersion,
+    build_dir: str | None,
+    target_toolchain: str | None,
+    is_mathlib: bool = False
+    )-> tuple[BuildResult | None, bool]:
   # Reset directory
   run_cmd('git', 'reset', '--hard')
   run_cmd('git', 'clean', '-ffdx')
@@ -61,6 +66,7 @@ def try_build(ver: PackageVersion, target_toolchain: str | None, is_mathlib=Fals
     'toolchain': target_toolchain,
     'requiredUpdate': False,
     'archiveSize': None,
+    'archiveHash': None,
     'runAt': utc_iso_now(),
     'url': None,
   }
@@ -91,14 +97,16 @@ def try_build(ver: PackageVersion, target_toolchain: str | None, is_mathlib=Fals
     result['built'] = False
     return result, True
   # Try to pack result
-  try:
-    with tempfile.TemporaryDirectory() as tmp:
-      archive = os.path.join(tmp, 'build.tgz')
-      run_cmd('lake', 'pack', archive)
-      archiveSize = result['archiveSize'] = os.path.getsize(archive)
-      logging.info(f'Packed build archive size: {fmt_bytes(archiveSize)} ({archiveSize})')
-  except Exception as e:
-    logging.error(f'Failed to pack build archive: {e}')
+  with tempfile.TemporaryDirectory() as tmp:
+    archive = os.path.join(tmp, 'build.barrel')
+    if run_cmd('lake', 'pack', archive, allow_failure=True) != 0:
+      logging.error('Failed to pack build archive')
+    else:
+      archive_size = result['archiveSize'] = os.path.getsize(archive)
+      logging.info(f'Packed build archive size: {fmt_bytes(archive_size)} ({archive_size})')
+      if build_dir is not None:
+        archive_hash = result['archiveHash'] = filehash(archive)
+        shutil.move(archive, os.path.join(build_dir, f"{archive_hash}.barrel"))
   # Try test
   if run_cmd('lake', 'check-test', allow_failure=True) == 0:
     success = result['tested'] = run_cmd('lake', 'test', allow_failure=True) == 0
@@ -111,17 +119,19 @@ def try_build(ver: PackageVersion, target_toolchain: str | None, is_mathlib=Fals
     logging.warning(f"No package test driver found; skipped testing")
   return result, False
 
-def try_add_build(ver: PackageVersion, target_toolchain: str | None, is_mathlib=False):
-  result, failure = try_build(ver, target_toolchain, is_mathlib)
-  if result is not None: ver['builds'].append(result)
-  return failure
-
-def try_add_builds(ver: PackageVersion, target_toolchains: Collection[str | None], is_mathlib=False):
+def try_add_builds(
+    ver: PackageVersion,
+    build_dir: str | None,
+    target_toolchains: Collection[str | None],
+    is_mathlib: bool = False
+    ):
   failure = False
   if len(target_toolchains) == 0:
     logging.info("No target toolchains specified; skipping build")
   for toolchain in target_toolchains:
-    failure = try_add_build(ver, toolchain, is_mathlib) or failure
+    result, toolchain_failure = try_build(ver, build_dir, toolchain, is_mathlib)
+    if result is not None: ver['builds'].append(result)
+    failure = toolchain_failure or failure
   return failure
 
 def cwd_toolchain():
@@ -191,7 +201,12 @@ def cwd_readme(cfg: ReservoirConfig | None):
 
 VERSION_TAG_PATTERN = re.compile(r'v(\d+).*')
 
-def cwd_analyze(target_toolchains: Collection[str | None] = [], tag_pattern: re.Pattern[str] | None = None) -> tuple[PackageResult, bool]:
+def cwd_analyze(
+    out_dir: str,
+    cache_builds: bool = False,
+    target_toolchains: Collection[str | None] = [],
+    tag_pattern: re.Pattern[str] | None = None
+    ) -> tuple[PackageResult, bool]:
   failure = False
   # Extract Reservoir configuration from Lake
   logging.info(f"Analyzing package HEAD")
@@ -246,9 +261,10 @@ def cwd_analyze(target_toolchains: Collection[str | None] = [], tag_pattern: re.
       version_tags = None
   # Index and build versions
   is_mathlib = result['name'] == 'mathlib'
+  build_dir = out_dir if cache_builds else None
   if result['doIndex']:
     if tag_pattern is None:
-      failure = try_add_builds(result['headVersion'], target_toolchains, is_mathlib) or failure
+      failure = try_add_builds(result['headVersion'], build_dir, target_toolchains, is_mathlib) or failure
     if version_tags is not None:
       logging.info(f'Detected version tags: {version_tags}')
       for tag in version_tags:
@@ -271,7 +287,7 @@ def cwd_analyze(target_toolchains: Collection[str | None] = [], tag_pattern: re.
         }
         result['versions'].append(ver)
         if tag_pattern is not None and tag_pattern.search(tag) is not None:
-          failure = try_add_builds(ver, target_toolchains, is_mathlib) or failure
+          failure = try_add_builds(ver, build_dir, target_toolchains, is_mathlib) or failure
   return result, failure
 
 if __name__ == "__main__":
@@ -281,13 +297,17 @@ if __name__ == "__main__":
   parser.add_argument('-m', '--matrix', type=str, default=None,
     help='JSON testbed matrix entry with build configuration')
   parser.add_argument('-d', '--testbed', type=str, default=None,
-    help="directory to clone the package into")
+    help="directory to test in and output results")
   parser.add_argument('-T', '--toolchain', type=str, nargs='*', action='extend', default=[],
     help="Lean toolchain(s) on build the package on")
   parser.add_argument('-o', '--output', type=str, default=None,
     help='file to output the build results')
   parser.add_argument('-V', '--version-tags', type=str, default=None,
     help='select version tags to build by regular expression')
+  parser.add_argument('--cache', action='store_false', default=True,
+    help="include build archives in artifact")
+  parser.add_argument('--no-cache', dest='cache', action='store_true',
+    help="do not include build archives in artifact")
   parser.add_argument('-q', '--quiet', dest="verbosity", action='store_const', const=0, default=1,
     help='print no logging information')
   parser.add_argument('-v', '--verbose', dest="verbosity", action='store_const', const=2,
@@ -305,49 +325,60 @@ if __name__ == "__main__":
     testbed = tempfile.mkdtemp()
     logging.debug(f"Created temporary testbed: {testbed}")
     reuse_clone = False
+    repo = os.path.join(testbed, 'repo')
   else:
-    testbed = args.testbed
-    reuse_clone = bool(args.reuse_clone) and os.path.exists(testbed)
+    testbed = os.path.abspath(args.testbed)
+    repo = os.path.join(testbed, 'repo')
+    reuse_clone = bool(args.reuse_clone) and os.path.exists(repo)
     if not reuse_clone:
-      os.makedirs(testbed, exist_ok=True)
-      shutil.rmtree(testbed)
+      os.makedirs(repo, exist_ok=True)
+      shutil.rmtree(repo)
+
+  # Make output directory
+  out_dir = os.path.join(testbed, 'artifact')
+  os.makedirs(out_dir, exist_ok=True)
 
   try:
+
     # Extract matrix configuration
     if args.matrix is not None:
       entry: TestbedEntry = json.loads(args.matrix)
       url = entry['gitUrl']
       target_toolchains = resolve_toolchains(entry['toolchains'])
+      version_tags = entry['versionTags']
+      cache_builds = entry['cacheBuilds']
     else:
       if args.url is None and not reuse_clone:
         raise RuntimeError("a Git URL is required (either by argument or through `--matrix`)")
       url: str | None = args.url
       target_toolchains = resolve_toolchains(args.toolchain)
+      version_tags = args.version_tags
+      cache_builds = args.cache
 
     # Compile version tag regex (if provided)
     tag_pattern: re.Pattern[str] | None = None
-    if args.version_tags == '':
+    if version_tags == '':
       tag_pattern = None
-    elif args.version_tags is not None:
-      tag_pattern = re.compile(args.version_tags)
+    elif version_tags is not None:
+      tag_pattern = re.compile(version_tags)
 
     # Clone, analyze, and build package
     iwd = os.getcwd()
-    os.chdir(testbed)
-    if url is not None:
+    logging.info(f"Setting up testbed in '{repo}'")
+    os.makedirs(repo, exist_ok=True)
+    os.chdir(repo)
+    if url is not None and not reuse_clone:
       run_cmd('git', 'clone', url, '.')
     run_cmd('git', 'fetch', '--tags', '--force')
     if args.head:
       cwd_checkout(args.head)
-    result, failure = cwd_analyze(target_toolchains, tag_pattern)
+    result, failure = cwd_analyze(out_dir, cache_builds, target_toolchains, tag_pattern)
     os.chdir(iwd)
 
     # Output result
-    if args.output is None:
-      print(json.dumps(result, indent=2))
-    else:
-      with open(args.output, 'w') as f:
-        f.write(json.dumps(result, indent=2))
+    result_file = ifnone(args.output, os.path.join(out_dir, 'result.json'))
+    with open(result_file, 'w') as f:
+      f.write(json.dumps(result, indent=2))
 
   finally:
     # Cleanup

--- a/scripts/testbed-analyze.py
+++ b/scripts/testbed-analyze.py
@@ -304,9 +304,9 @@ if __name__ == "__main__":
     help='file to output the build results')
   parser.add_argument('-V', '--version-tags', type=str, default=None,
     help='select version tags to build by regular expression')
-  parser.add_argument('--cache', action='store_false', default=True,
+  parser.add_argument('--cache', action='store_true', default=True,
     help="include build archives in artifact")
-  parser.add_argument('--no-cache', dest='cache', action='store_true',
+  parser.add_argument('--no-cache', dest='cache', action='store_false',
     help="do not include build archives in artifact")
   parser.add_argument('-q', '--quiet', dest="verbosity", action='store_const', const=0, default=1,
     help='print no logging information')

--- a/scripts/testbed-collect.py
+++ b/scripts/testbed-collect.py
@@ -2,7 +2,6 @@
 from utils import *
 from typing import TypedDict
 import json
-import re
 import argparse
 import os
 
@@ -51,6 +50,9 @@ if __name__ == "__main__":
 
   configure_logging(args.verbosity)
 
+  if not S3_ENABLED:
+    logging.warning("No cloud storage configured; will not retain build archives")
+
   jobs = query_jobs(args.repo, args.run_id, args.run_attempt)
   def find_testbed_job_id(name: str) -> int | None:
     return next((job['id'] for job in jobs if job['name'].split(' / ')[-1] == name), None)
@@ -68,14 +70,15 @@ if __name__ == "__main__":
   num_opt_outs = 0
   num_build_results = 0
   results: TestbedResults = list[TestbedResult]()
-  archiveSizes = list[int]()
+  archive_sizes = list[int]()
   for entry in entries:
     jobId = find_testbed_job_id(entry['jobName'])
     if jobId is None:
       logging.error(f"Job ID not found for '{entry['jobName']}'")
       continue
     url = f"https://github.com/{TESTBED_REPO}/actions/runs/{args.run_id}/job/{jobId}#step:4:1"
-    result_file = os.path.join(args.results, entry['artifact'], 'result.json')
+    artifact_dir = os.path.join(args.results, entry['artifact'])
+    result_file = os.path.join(artifact_dir, 'result.json')
     try:
       with open(result_file, 'r') as f:
         result: TestbedResult = mk_testbed_result(entry, json.load(f))
@@ -88,15 +91,30 @@ if __name__ == "__main__":
     for build in walk_builds(result):
       build['url'] = url
       num_build_results += 1
-      archiveSize = build.get('archiveSize', None)
-      if archiveSize is not None:
-        archiveSizes.append(archiveSize)
+      archive_size = build.get('archiveSize', None)
+      if archive_size is not None:
+        archive_sizes.append(archive_size)
+      archive_hash = build.get('archiveHash', None)
+      if archive_hash is None:
+        continue
+      archive = os.path.join(artifact_dir, f"{archive_hash}.barrel")
+      if not os.path.exists(archive):
+        logging.error(f"[{entry['jobName']}] Hash recorded for build archive, but file not found")
+        continue
+      content_hash = filehash(archive)
+      if content_hash != archive_hash:
+        logging.error(f"[{entry['jobName']}] Build archive hash does not matched recorded hash")
+        continue
+      if S3_ENABLED:
+        upload_build(archive, archive_size, archive_hash)
 
   # Print stats
   logging.info(f"Package results: {len(results)} ({num_opt_outs} opt-outs)")
-  num_archives = len(archiveSizes)
+  num_archives = len(archive_sizes)
   logging.info(f"Build results: {num_build_results} ({num_archives} with archives)")
-  avg = 0 if num_archives == 0 else round(sum(archiveSizes)/num_archives)
+  total_size = sum(archive_sizes)
+  logging.info(f'Total size of build archives: {fmt_bytes(total_size)} ({total_size} bytes)')
+  avg = 0 if num_archives == 0 else round(total_size/num_archives)
   logging.info(f'Average build archive size: {fmt_bytes(avg)} ({avg} bytes)')
 
   # Output results

--- a/scripts/testbed-collect.py
+++ b/scripts/testbed-collect.py
@@ -40,8 +40,10 @@ if __name__ == "__main__":
     help="file containing the JSON build matrix")
   parser.add_argument('-o', '--output',
     help='file to output the collected results')
-  parser.add_argument('-R', '--repo',
-    help='repository with testbed jobs', default=TESTBED_REPO)
+  parser.add_argument('-R', '--repo', default=TESTBED_REPO,
+    help='repository with testbed jobs')
+  parser.add_argument('--prod-cache', action='store_true',
+    help='upload builds to main build cache')
   parser.add_argument('-q', '--quiet', dest="verbosity", action='store_const', const=0, default=1,
     help='print no logging information')
   parser.add_argument('-v', '--verbose', dest="verbosity", action='store_const', const=2,
@@ -105,8 +107,8 @@ if __name__ == "__main__":
       if content_hash != archive_hash:
         logging.error(f"[{entry['jobName']}] Build archive hash does not matched recorded hash")
         continue
-      if S3_ENABLED:
-        upload_build(archive, archive_size, archive_hash)
+      if result['doIndex'] and S3_ENABLED:
+        upload_build(archive, archive_size, archive_hash, args.prod_cache)
 
   # Print stats
   logging.info(f"Package results: {len(results)} ({num_opt_outs} opt-outs)")

--- a/scripts/testbed-create.py
+++ b/scripts/testbed-create.py
@@ -47,9 +47,9 @@ if __name__ == "__main__":
     help="max number of testbed entries (< 0 for no limit)")
   parser.add_argument('-Q', '--query', type=int, default=0,
     help='(max) number of new packages to query from GitHub (< 0 for no limit)')
-  parser.add_argument('--cache', action='store_false', default=True,
+  parser.add_argument('--cache', action='store_true', default=True,
     help="upload build archives in cloud storage")
-  parser.add_argument('--no-cache', dest='cache', action='store_true',
+  parser.add_argument('--no-cache', dest='cache', action='store_false',
     help="do not upload build archives in cloud storage")
   parser.add_argument('-X', '--exclusions', default=default_exclusions,
     help='file containing repos to exclude')

--- a/scripts/testbed-create.py
+++ b/scripts/testbed-create.py
@@ -22,7 +22,7 @@ def create_entry(
     'jobName': job_name,
     'toolchains': toolchains,
     'versionTags': version_tags,
-    'cacheBuilds': True,
+    'cacheBuilds': cache_builds,
     "repoId": repo_id,
     "indexName": index_name,
   }
@@ -47,6 +47,10 @@ if __name__ == "__main__":
     help="max number of testbed entries (< 0 for no limit)")
   parser.add_argument('-Q', '--query', type=int, default=0,
     help='(max) number of new packages to query from GitHub (< 0 for no limit)')
+  parser.add_argument('--cache', action='store_false', default=True,
+    help="upload build archives in cloud storage")
+  parser.add_argument('--no-cache', dest='cache', action='store_true',
+    help="do not upload build archives in cloud storage")
   parser.add_argument('-X', '--exclusions', default=default_exclusions,
     help='file containing repos to exclude')
   parser.add_argument('-o', '--output',
@@ -109,7 +113,11 @@ if __name__ == "__main__":
       if git_url is None:
         logging.error(f"{pkg['fullName']}: Package lacks a Git source")
       else:
-        cache_builds = pkg['owner'] == 'leanprover'
+        cache_builds = (
+          args.cache and
+          pkg['owner'] in ['leanprover', 'leanprover-community'] and
+          pkg['fullName'] != 'leanprover-community/mathlib'
+        )
         entry = create_entry(
           pkg['fullName'], git_url,
           toolchains, args.version_tags, cache_builds,

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -2,3 +2,4 @@ from utils.manifest import *
 from utils.index import *
 from utils.toolchain import *
 from utils.repo import *
+from utils.upload import *

--- a/scripts/utils/core.py
+++ b/scripts/utils/core.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import itertools
+import hashlib
 from datetime import datetime, timezone
 from typing import TypeVar, Iterable, Iterator, Literal, overload
 
@@ -31,6 +32,17 @@ def fmt_bytes(num: float):
 
 def ifnone(value: T | None, default: T) -> T:
   return default if value is None else value
+
+# adapted from https://stackoverflow.com/a/44873382
+def filehash(path: str) -> str:
+    "SHA-256 hash of a file"
+    h  = hashlib.sha256()
+    b  = bytearray(128*1024)
+    mv = memoryview(b)
+    with open(path, 'rb', buffering=0) as f:
+        while n := f.readinto(mv):
+            h.update(mv[:n])
+    return h.hexdigest()
 
 #---
 # Time

--- a/scripts/utils/index.py
+++ b/scripts/utils/index.py
@@ -77,6 +77,7 @@ def of_build_v0(build: BuildV0) -> Build:
     'built': build['outcome'] == 'success',
     'tested': None,
     'archiveSize': build.get('archiveSize', None),
+    'archiveHash': build.get('archiveHash', None),
     'toolchain': build['toolchain'],
     'requiredUpdate': build.get('requiredUpdate', None),
     'revision': build['revision'],
@@ -99,7 +100,10 @@ def load_builds(path: str) -> list[Build]:
   with open(path, 'r') as f:
     data: Any = json.load(f)
   if isinstance(data, dict):
-    return data['data']
+    builds = data['data']
+    for build in builds:
+      build['archiveHash'] = build.get('archiveHash', None)
+    return builds
   else:
     return list(map(of_build_v0, data))
 

--- a/scripts/utils/package.py
+++ b/scripts/utils/package.py
@@ -85,7 +85,9 @@ class TestbedResult(PackageResult):
 
 TestbedResults = list[TestbedResult]
 
-INDEX_SCHEMA_VERSION_STR = '1.0.0'
+#`1.0.0: Reservoir 1.0
+# 1.1.0: Added `archiveHash`
+INDEX_SCHEMA_VERSION_STR = '1.1.0'
 INDEX_SCHEMA_VERSION = Version(INDEX_SCHEMA_VERSION_STR)
 
 class PackageMetadata(TypedDict):
@@ -154,7 +156,7 @@ def mk_build(ver: PackageVersion, build: BuildResult) -> Build:
   return build
 
 def build_result(build: Build) -> BuildResult:
-  return cast(BuildResult, {k: build[k] for k in BuildResult.__annotations__.keys()})
+  return cast(BuildResult, {k: build.get(k, None) for k in BuildResult.__annotations__.keys()})
 
 def serialize_package(pkg: Package) -> SerialPackage:
   r = cast(SerialPackage, package_metadata(pkg))

--- a/scripts/utils/package.py
+++ b/scripts/utils/package.py
@@ -32,6 +32,7 @@ class BuildResult(TypedDict):
   toolchain: str
   requiredUpdate: bool | None
   archiveSize: int | None
+  archiveHash: str | None
   runAt: str
   url: str | None
 
@@ -68,6 +69,7 @@ class TestbedEntry(TypedDict):
   jobName: str
   toolchains: str
   versionTags: str
+  cacheBuilds: bool
   repoId: str | None
   indexName: str | None
 

--- a/scripts/utils/upload.py
+++ b/scripts/utils/upload.py
@@ -56,13 +56,14 @@ S3_ENDPOINT = os.environ.get("S3_ENDPOINT", '').rstrip('/')
 S3_ACCESS_KEY_ID = os.environ.get('S3_ACCESS_KEY_ID', '')
 S3_SECRET_ACCESS_KEY = os.environ.get('S3_SECRET_ACCESS_KEY', '')
 S3_ENABLED = S3_ENDPOINT != '' and S3_ACCESS_KEY_ID != '' and S3_SECRET_ACCESS_KEY != ''
-def upload_build(path: str, size: int | None = None, hash: str | None = None):
+def upload_build(path: str, size: int | None = None, hash: str | None = None, prod_cache: bool = False):
   if not S3_ENABLED:
     raise RuntimeError("No cloud storage configured")
   method = 'PUT'
   if size is None: size = os.path.getsize(path)
   if hash is None: hash = filehash(path)
-  url = f"{S3_ENDPOINT}/b1/{hash}.barrel"
+  group = 'b1' if prod_cache else 'dev'
+  url = f"{S3_ENDPOINT}/{group}/{hash}.barrel"
   headers = aws4_headers(method, url, 's3', S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, hash)
   headers['content-length'] = str(size)
   headers['content-type'] = "application/vnd.reservoir.barrel+gzip"

--- a/scripts/utils/upload.py
+++ b/scripts/utils/upload.py
@@ -1,0 +1,72 @@
+import os
+import hmac
+import hashlib
+import requests
+from typing import Mapping
+from datetime import datetime, timezone
+from urllib.parse import urlparse, quote
+from utils.core import filehash
+
+# R2 client code adapted from https://github.com/fayharinn/R2-Client
+
+def hmac_sha256(key: bytes, content: bytes):
+  return hmac.new(key, content, hashlib.sha256).digest()
+
+def aws4_signing_key(key: str, date: str, region: str, service: str):
+  k_date = hmac_sha256(f"AWS4{key}".encode(), date.encode())
+  k_region = hmac_sha256(k_date, region.encode())
+  k_service = hmac_sha256(k_region, service.encode())
+  k_signing = hmac_sha256(k_service, 'aws4_request'.encode())
+  return k_signing
+
+def aws4_uri_encode(string: str):
+  return quote(string)
+
+def aws4_headers(
+    method: str, url: str, service: str,
+    access_key_id: str, secret_access_key: str,
+    payload_hash: str, region: str = 'auto',
+    params: Mapping[str,str] = {}, headers: Mapping[str, str] = {}):
+  url_parts = urlparse(url)
+  host = str(url_parts.hostname) if url_parts.port is None else f"{url_parts.hostname}:{url_parts.port}"
+  canonical_uri = aws4_uri_encode(url_parts.path)
+  now = datetime.now(timezone.utc)
+  amz_date = now.strftime('%Y%m%dT%H%M%SZ')
+  date_stamp = now.strftime('%Y%m%d')
+  algorithm = 'AWS4-HMAC-SHA256'
+  headers = {k.lower(): v.strip() for k, v in headers.items()}
+  headers['host'] = host
+  headers['x-amz-content-sha256'] = payload_hash
+  headers['x-amz-date'] = amz_date
+  canonical_headers = ''.join(f"{h}:{v}\n" for h, v in headers.items())
+  signed_headers = ";".join(headers.keys())
+  canonical_query = '&'.join(f"{aws4_uri_encode(p)}={aws4_uri_encode(v)}" for p, v in params)
+  canonical_request = f"{method}\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+  hashed_request = hashlib.sha256(canonical_request.encode()).hexdigest()
+  credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+  string_to_sign = f"{algorithm}\n{amz_date}\n{credential_scope}\n{hashed_request}"
+  signing_key = aws4_signing_key(secret_access_key, date_stamp, region, service)
+  signature = hmac_sha256(signing_key, string_to_sign.encode()).hex()
+  authorization = f"{algorithm} Credential={access_key_id}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
+  headers['authorization'] = authorization
+  return headers
+
+S3_SESSION = requests.Session()
+S3_ENDPOINT = os.environ.get("S3_ENDPOINT", '').rstrip('/')
+S3_ACCESS_KEY_ID = os.environ.get('S3_ACCESS_KEY_ID', '')
+S3_SECRET_ACCESS_KEY = os.environ.get('S3_SECRET_ACCESS_KEY', '')
+S3_ENABLED = S3_ENDPOINT != '' and S3_ACCESS_KEY_ID != '' and S3_SECRET_ACCESS_KEY != ''
+def upload_build(path: str, size: int | None = None, hash: str | None = None):
+  if not S3_ENABLED:
+    raise RuntimeError("No cloud storage configured")
+  method = 'PUT'
+  if size is None: size = os.path.getsize(path)
+  if hash is None: hash = filehash(path)
+  url = f"{S3_ENDPOINT}/b1/{hash}.barrel"
+  headers = aws4_headers(method, url, 's3', S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, hash)
+  headers['content-length'] = str(size)
+  headers['content-type'] = "application/vnd.reservoir.barrel+gzip"
+  with open(path, 'rb') as f:
+    resp = S3_SESSION.request(method, url, data=f, headers=headers)
+  if resp.status_code != 200:
+    raise RuntimeError(f"Failed to upload build ({resp.status_code}): {resp.text}")

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -29,6 +29,7 @@ export interface Build {
   tested: boolean | null
   requiredUpdate?: boolean | null
   archiveSize?: number | null
+  archiveHash?: string | null
 }
 
 export interface PackageDep {


### PR DESCRIPTION
Built packages are now packed and uploaded to the Reservoir cloud storage (an S3 bucket). Currently only enabled for packages within the the `leanprover` and `leanprover-community` organizations. Also excludes Mathlib, since it has its own cache.