### PR TITLE
feat: add terms & privacy policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ publish = "site/.output/public/"
 
 [dev]
 command = "npm run dev"
-port = 3000
+targetPort = 3000
 publish = "site/.output/public/"
 
 [functions]

--- a/site/components/FooterLinks.vue
+++ b/site/components/FooterLinks.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import GitHubIcon from '~icons/simple-icons/github'
-import TwitterIcon from '~icons/simple-icons/twitter'
+import XIcon from '~icons/simple-icons/x'
 import LinkedinIcon from '~icons/simple-icons/linkedin'
 import ZulipIcon from '~icons/simple-icons/zulip'
 </script>
@@ -8,17 +8,26 @@ import ZulipIcon from '~icons/simple-icons/zulip'
 <template>
   <div class="footer-links">
     <div>
-      <h2 class="group-header">Lean</h2>
+      <h2 class="group-header">About</h2>
       <ul>
         <li><a href="https://lean-lang.org/">lean-lang.org</a></li>
         <li><a href="https://lean-fro.org/">The Lean FRO</a></li>
-        <li><a href="https://leanprover-community.github.io/">Lean Community</a></li>
-        <li><a href="https://github.com/leanprover/lean4/issues">Report a bug</a></li>
-        <li><a href="https://loogle.lean-fro.org/">Loogle</a></li>
+        <li><NuxtLink to="/policies/terms">Terms of Use</NuxtLink></li>
+        <li><NuxtLink to="/policies/privacy">Privacy Policy</NuxtLink></li>
       </ul>
     </div>
     <div>
-      <h2 class="group-header">Books</h2>
+      <h2 class="group-header">Explore</h2>
+      <ul>
+        <li><a href="https://adam.math.hhu.de//">Games</a></li>
+        <li><a href="https://live.lean-lang.org/">Playground</a></li>
+        <li><a href="https://leanprover-community.github.io/">Community</a></li>
+        <li><a href="https://moogle.ai/">Moogle</a></li>
+        <li><a href="https://loogle.lean-lang.org/">Loogle</a></li>
+      </ul>
+    </div>
+    <div>
+      <h2 class="group-header">Learn</h2>
       <ul>
         <li><a href="https://lean-lang.org/lean4/doc/whatIsLean.html">The Lean Manual</a></li>
         <li><a href="https://lean-lang.org/theorem_proving_in_lean4/">Theorem Proving in Lean</a></li>
@@ -38,7 +47,7 @@ import ZulipIcon from '~icons/simple-icons/zulip'
         </li>
         <li>
           <a href="https://twitter.com/leanprover">
-            <TwitterIcon class="prefix icon"/><span>@leanprover</span>
+            <XIcon class="prefix icon"/><span>@leanprover</span>
           </a>
         </li>
         <li>

--- a/site/pages/policies/privacy.vue
+++ b/site/pages/policies/privacy.vue
@@ -1,0 +1,808 @@
+<!-- Adapted from an external resource -->
+
+<template>
+  <div class="card c26 doc-content">
+    <div>
+      <h2 class="c37" id="h.vaazd9g5xuwm"><span class="c14 c35">Privacy Policy</span></h2>
+    </div>
+    <p class="c28"><span class="c4">Last modified: July 24, 2024</span></p>
+    <p class="c38"><span class="c6"></span></p>
+    <p class="c41"><span class="c9">We at Lean FRO, LLC, together with our parent, subsidiaries, and affiliates,
+        (collectively, &ldquo;</span><span class="c14">we</span><span class="c9">&rdquo;, &ldquo;</span><span
+        class="c14">us</span><span class="c9">&rdquo;, &ldquo;</span><span class="c14">our</span><span
+        class="c9">&rdquo;), respect your privacy and are strongly committed to keeping secure any information we obtain
+        from you or about you. This Privacy Policy describes our practices with respect to Personal Information we collect
+        from or about you when you access our websites or use our products and services, including application programming
+        interfaces, associated software, tools, developer services, data and documentation, content, events, or activities
+        (collectively, the &ldquo;</span><span class="c14">Services</span><span class="c6">&rdquo;). We also describe your
+        privacy rights and choices; how we transfer, retain, and protect data; and other aspects of our privacy program.
+      </span></p>
+    <h3 class="c2" id="h.gjdgxs"><span class="c11">1. Personal Information We Collect</span></h3>
+    <p class="c20"><span class="c9">We collect information that alone or in combination with other information in our
+        possession could be used to identify you (&ldquo;</span><span class="c14">Personal Information</span><span
+        class="c6">&rdquo;) as follows:</span></p>
+    <p class="c8 c29"><span class="c14">Personal Information You Provide</span><span class="c6">: We may collect Personal
+        Information if you create an account to use our Services or communicate with us as follows:</span></p>
+    <ul class="c16 lst-kix_list_5-0 start">
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Account Information:</span><span class="c9">&nbsp;When you create
+          an account with us, we will collect information associated with your account, including your name, contact
+          information, account credentials, payment card information, and transaction history, (collectively,
+          &ldquo;</span><span class="c14">Account Information</span><span class="c9">&rdquo;).</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">User Content:</span><span class="c9">&nbsp;When you use our
+          Services, we may collect Personal Information that is included in the input, file uploads, or feedback that you
+          provide to our Services (&ldquo;</span><span class="c14">Content</span><span class="c9">&rdquo;). </span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Communication Information</span><span class="c9">: If you
+          communicate with us, we may collect your name, contact information, and the contents of any messages you send
+          (&ldquo;</span><span class="c14">Communication Information</span><span class="c9">&rdquo;).</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Social Media Information</span><span class="c9">: We have pages
+          on social media sites like X, and LinkedIn. When you interact with our social media pages, we will collect
+          Personal Information that you elect to provide to us, such as your contact details (collectively,
+          &ldquo;</span><span class="c14">Social Information</span><span class="c9">&rdquo;). In addition, the companies
+          that host our social media pages may provide us with aggregate information and analytics about our social media
+          activity.</span></li>
+    </ul>
+    <p class="c20 c8"><span class="c14">Personal Information We Receive Automatically From Your Use of the
+        Services:</span><span class="c9">&nbsp;When you visit, use, and interact with the Services, we may receive the
+        following information about your visit, use, or interactions (&ldquo;</span><span class="c14">Technical
+        Information</span><span class="c6">&rdquo;):</span></p>
+    <ul class="c16 lst-kix_list_6-0 start">
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Log Data</span><span class="c9">: Information that your browser
+          automatically sends whenever you user our website(&ldquo;</span><span class="c14">log data</span><span
+          class="c9">&rdquo;). Log data includes your Internet Protocol address, browser type and settings, the date and
+          time of your request, and how you interacted with our website.</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Usage Data</span><span class="c6">: We may automatically collect
+          information about your use of the Services, such as the types of content that you view or engage with, the
+          features you use and the actions you take, as well as your time zone, country, the dates and times of access,
+          user agent and version, type of computer or mobile device, computer connection, IP address, and the like.</span>
+      </li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Device Information</span><span class="c6">: Includes name of the
+          device, operating system, and browser you are using. Information collected may depend on the type of device you
+          use and its settings.</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Cookies</span><span class="c9">: We use cookies to operate and
+          administer our Services, and improve your experience on it. A &ldquo;cookie&rdquo; is a piece of information
+          sent to your browser by a website you visit. You can set your browser to accept all cookies, to reject all
+          cookies, or to notify you whenever a cookie is offered so that you can decide each time whether to accept it.
+          However, refusing a cookie may in some cases preclude you from using, or negatively affect the display or
+          function of, a website or certain areas or features of a website. For more details on cookies please visit
+        </span><span class="c32 c9"><a class="c27" href="https://allaboutcookies.org/">All About Cookies</a></span><span class="c6">.</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Analytics</span><span class="c6">: We may use a variety of online
+          analytics products that use cookies to help us analyze how users use our Services and enhance your experience
+          when you use the Services.</span></li>
+    </ul>
+    <p class="c20"><span class="c14">Other Personal Information: </span><span class="c6">We may collect other Personal
+        Information from a variety of sources:</span></p>
+    <ul class="c16 lst-kix_list_4-0 start">
+      <li class="c5 li-bullet-0"><span class="c9 c10">Photos and videos</span><span class="c6">: &nbsp;We may collect
+          photos and videos captured at events or shared on any interactive areas of the Services, such as a community or
+          blog.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Information we derive or infer about you</span><span class="c6">:
+          &nbsp;We may collect evaluations, observations and inferences we derive from the information we obtain about
+          you.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Information from third parties</span><span class="c6">: &nbsp;This
+          includes information provided to us by event participants, or your colleagues or contacts who submit information
+          to us about their ideas or proposals, or others.</span></li>
+    </ul>
+    <h3 class="c21" id="h.30j0zll"><span class="c11">2. WHY WE USE PERSONAL INFORMATION</span></h3>
+    <p class="c20"><span class="c9">Certain laws, such as </span><span class="c9 c32"><a class="c27"
+          href="https://gdpr-info.eu/">GDPR</a></span><span
+        class="c9">, describe various lawful reasons to &ldquo;process&rdquo; (</span><span class="c9 c10">i.e</span><span
+        class="c6">. collect, use, and share) personal information. Our reasons for processing are described below:</span>
+    </p>
+    <ul class="c16 lst-kix_list_10-0 start">
+      <li class="c30 c25 li-bullet-0"><span class="c9 c10">Consent</span><span class="c9">: We ask for your consent to
+          process your personal information for specified purposes at relevant times when you interact with the Site or
+          Services.</span></li>
+      <li class="c25 c30 li-bullet-0"><span class="c9 c10">Contract</span><span class="c9">: We process your information
+          as necessary for the performance of a contract you have entered into with us, such as the Terms of Use or an
+          event release.</span></li>
+      <li class="c30 c25 li-bullet-0"><span class="c9 c10">Legal Obligations</span><span class="c9">: We process
+          information to comply with legal, tax, and compliance obligations or lawful requests for information from a
+          court or government authority.</span></li>
+      <li class="c30 c25 li-bullet-0"><span class="c9 c10">Protection from Harm</span><span class="c9">: We process
+          information where necessary to protect an individual from serious physical harm or injury.</span></li>
+      <li class="c30 c25 li-bullet-0"><span class="c9 c10">Legitimate Interests</span><span class="c9">: We process
+          information for our and others&rsquo; (including your) legitimate interests, such as commercial interests,
+          individual interests or broader societal benefits. We rely on &ldquo;legitimate interests&rdquo; when we use
+          data in ways people would reasonably expect based on the circumstances, and where the use would have a minimal
+          privacy impact, or where there is a compelling justification for the use. Our legitimate interests are described
+          in &nbsp;&ldquo;How We Use Data&rdquo; below. </span></li>
+    </ul>
+    <h3 class="c21" id="h.eh5cqi94v6uv"><span class="c11">3. HOW WE USE PERSONAL INFORMATION</span></h3>
+    <p class="c20"><span class="c6">We may use personal information for the following purposes:</span></p>
+    <p class="c20"><span class="c24 c14">Provide the Services: Legitimate interests</span></p>
+    <ul class="c16 lst-kix_list_1-0 start">
+      <li class="c1 li-bullet-0"><span class="c6">&nbsp;Identify you</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Communicate with you about the Services and respond to your
+          communications</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Provide websites, newsletters, blogs, community spaces, or other
+          interactive features</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Review your submissions of ideas or proposals</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Provide requested content and programming</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Publish content (such as journal articles)</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Obtain services to operate and manage the Services, such as web and
+          database hosting, IT support, operations, communication services, research tools, and data analytics</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Enable connections you request between the Services and third party
+          tools or services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Build and develop the Services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Organize, host, and invite people to events (e.g. conferences)</span>
+      </li>
+      <li class="c1 li-bullet-0"><span class="c6">Tailor the Services to local customs and industry standards</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Maintain health and safety at in-person events</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Provide reasonable accommodations</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Provide relevant or personalized content</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Improve the accuracy of the Services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Verify information provided to us</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Enforce our policies and terms</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Perform data analytics, accounting, auditing and other internal
+          functions</span></li>
+    </ul>
+    <p class="c12"><span class="c14 c24">Marketing communications and use of non-essential cookies and other technologies:
+        Consent</span></p>
+    <ul class="c16 lst-kix_list_9-0 start">
+      <li class="c12 c25 li-bullet-0"><span class="c6">Send emails promoting goods and services other than the Services
+          you&rsquo;ve requested</span></li>
+    </ul>
+    <p class="c12"><span class="c24 c14">Safety and security: Legitimate interests</span></p>
+    <ul class="c16 lst-kix_list_8-0 start">
+      <li class="c12 c25 li-bullet-0"><span class="c6">Maintain and enhance the safety and security of the Services,
+          protect against and prevent fraud, misuse, unauthorized transactions, claims, and other liabilities</span></li>
+    </ul>
+    <p class="c12"><span class="c24 c14">Research: Legitimate interests</span></p>
+    <ul class="c16 lst-kix_list_2-0 start">
+      <li class="c1 li-bullet-0"><span class="c6">Support research, analysis, and publication on topics relevant to the
+          Services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Improve the Services and develop new services: Legitimate
+          interests</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Evaluate and improve the Services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Perform debugging to identify, prevent, and repair errors that impair or
+          may impair the Services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Verify or maintain the quality of the Services</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Develop new programs and services, including new Focused Research
+          Organizations</span></li>
+    </ul>
+    <p class="c12"><span class="c24 c14">Legal compliance and claims: Legal obligations</span></p>
+    <ul class="c16 lst-kix_list_2-0">
+      <li class="c1 li-bullet-0"><span class="c6">Comply with applicable laws and regulations</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Maintain or defend legal claims</span></li>
+      <li class="c1 li-bullet-0"><span class="c6">Respond to valid requests for information from courts, litigants, and
+          governmental or official agencies and organizations</span></li>
+    </ul>
+    <p class="c12"><span class="c24 c14">Other uses</span></p>
+    <ul class="c16 lst-kix_list_2-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c6">We also may use information in other ways for
+            which we will provide information when and if such uses arise </span>
+      </li>
+    </ul>
+    <p class="c20 c8"><span class="c14">Aggregated or De-Identified Information</span><span class="c6">. We may aggregate
+        or de-identify Personal Information and use the aggregated information to analyze the effectiveness of our
+        Services, to improve and add features to our Services, to conduct research &nbsp;and for other similar purposes.
+        In addition, from time to time, we may analyze the general behavior and characteristics of users of our Services
+        and share aggregated information like general user statistics with third parties, publish such aggregated
+        information or make such aggregated information generally available. We may collect aggregated information through
+        the Services, through cookies, and through other means described in this Privacy Policy. We will maintain and use
+        de-identified information in anonymous or de-identified form and we will not attempt to reidentify the
+        information.</span></p>
+    <h3 class="c2" id="h.tyjcwt"><span class="c11">4. INFORMATION SHARING</span></h3>
+    <p class="c20"><span class="c0">In certain circumstances we may provide your Personal Information to third parties
+        without further notice to you, unless required by the law:</span></p>
+    <ul class="c16 lst-kix_list_12-0 start">
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Affiliates</span><span class="c6">: We may disclose Personal
+          Information to our affiliates, meaning an entity that controls, is controlled by, or is under common control
+          with Convergent Research. Our affiliates may use the Personal Information we share in a manner consistent with
+          this Privacy Policy.</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Other Participants</span><span class="c9">: Information you share
+          in public-facing areas of the Site or Services, community features, or at events will be visible to anyone with
+          access to those public spaces (virtual or physical).</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Professional Connections</span><span class="c9">: We may disclose
+          Personal Information to individuals in our constituents&rsquo; professional networks. &nbsp;</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Vendors and Service Providers</span><span class="c6">: To assist
+          us in meeting business operations needs and to perform certain services and functions, we may provide Personal
+          Information to vendors and service providers, including providers of hosting services, cloud services, and other
+          information technology services providers, event management services, email communication software and email
+          newsletter services, and web analytics services. Pursuant to our instructions, these parties will access,
+          process, or store Personal Information only in the course of performing their duties to us.</span></li>
+    </ul>
+    <ul class="c16 lst-kix_list_12-1 start">
+      <li class="c20 c40 c8 li-bullet-0"><span class="c6">Most of our service providers are located in the United
+          States.</span></li>
+      <li class="c20 c8 c40 li-bullet-0"><span class="c6">We do not authorize service providers to use or disclose
+          information except as necessary to perform services on our behalf or comply with legal requirements.</span></li>
+    </ul>
+    <ul class="c16 lst-kix_list_12-0">
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Business Transfers</span><span class="c9">: If we are involved in
+          strategic transactions, reorganization, bankruptcy, receivership, or transition of service to another provider
+          (collectively a &ldquo;</span><span class="c14">Transaction</span><span class="c9">&rdquo;), your Personal
+          Information and other information may be disclosed in the diligence process with counterparties and others
+          assisting with the Transaction and transferred to a successor or affiliate as part of that Transaction along
+          with other assets.</span></li>
+      <li class="c5 c8 li-bullet-0"><span class="c9 c10">Legal Requirements</span><span class="c6">: If required to do so
+          by law or in the good faith belief that such action is necessary to (i) comply with a legal obligation,
+          including to meet national security or law enforcement requirements, (ii) protect and defend our rights or
+          property, (iii) prevent fraud, (iv) act in urgent circumstances to protect the personal safety of users of the
+          Services, or the public, or (v) protect against legal liability.</span></li>
+    </ul>
+    <p class="c20"><span class="c6">Please contact us as specified in the &ldquo;How To Contact Us&rdquo; section of this
+        Privacy Notice if you would like to obtain more information about the affiliates, subsidiaries and other third
+        parties with whom we may share personal information.</span></p>
+    <h3 class="c2" id="h.3dy6vkm"><span class="c11">5. YOUR RIGHTS AND CHOICES</span></h3>
+    <p class="c20"><span class="c6">We offer you certain choices in connection with the personal information we collect
+        from you. To update your preferences, limit the communications you receive from us, or submit a request, please
+        contact us as indicated in the &ldquo;How To Contact Us&rdquo; section of this Privacy Notice. You can unsubscribe
+        from our marketing mailing lists by following the &ldquo;Unsubscribe&rdquo; link in our emails or contacting us as
+        specified in the &ldquo;How To Contact Us&rdquo; section below. We will apply your preferences going
+        forward.</span></p>
+    <p class="c20"><span class="c9">Depending on the laws that apply to you, including </span><span class="c32 c9"><a
+          class="c27"
+          href="https://www.google.com/url?q=https://gdpr-info.eu/&amp;sa=D&amp;source=editors&amp;ust=1727970818484304&amp;usg=AOvVaw3WJyNvPMMwE84A5eUOCoEO">GDPR</a></span><span
+        class="c6">, you may have the rights provided below, some of which may apply generally, and some of which apply
+        only in certain circumstances, described below: </span></p>
+    <ul class="c16 lst-kix_list_7-0 start">
+      <li class="c5 li-bullet-0"><span class="c9 c10">Access</span><span class="c9">: Access personal information we
+          process about you and obtain information about our processing.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Rectification</span><span class="c9">: Correct inaccurate
+          information or supplement incomplete information.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Erasure</span><span class="c9">: Erase personal information, when,
+          for instance, it is no longer needed or where you have withdrawn your consent and there is no other legal basis
+          for the processing.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Restrict Processing</span><span class="c6">: Limit our processing of
+          your information, for instance, where we no longer need it but you do not want it to be erased because it is
+          needed in connection with a legal claim.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Object</span><span class="c6">: Object to processing for direct
+          marketing purposes, or to processing based on &ldquo;legitimate interests&rdquo; (explained above) unless we
+          have compelling reasons to continue processing or where it is needed in connection with a legal claim.</span>
+      </li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Withdraw consent</span><span class="c9">: Withdraw consent
+          you&rsquo;ve previously given, without penalty, but we will have to cease carrying out the purposes for which
+          you consented to processing, which may affect our ability to provide certain aspects of the Site or Services to
+          you.</span></li>
+      <li class="c5 li-bullet-0"><span class="c9 c10">Portability</span><span class="c9">: Request that we provide you a
+          copy of personal information you have provided us, where the processing is based on consent or is carried out by
+          automated means.</span></li>
+    </ul>
+    <p class="c20"><span class="c6">To exercise any of these rights, please contact us as indicated in the &ldquo;How To
+        Contact Us&rdquo; section below. If you are located in the European Economic Area (EEA), you also may lodge a
+        complaint with the data protection authority in your country of residence. </span></p>
+    <h3 class="c8 c36" id="h.cv80hxfrecfp"><span class="c11">6. California privacy rights</span></h3>
+    <p class="c12 c8"><span class="c6">The following table provides additional information about how we disclose Personal
+        Information. You can read more about the Personal Information we collect in &ldquo;Personal information we
+        collect&rdquo; above, how we use Personal information in &ldquo;How we use personal information&rdquo; above, and
+        how we retain personal information in &ldquo;Retention of Personal Information&rdquo; below.</span></p>
+    <table class="c23">
+      <thead>
+        <tr class="c34">
+          <td class="c7" colspan="1" rowspan="1">
+            <p class="c19"><span class="c24 c14">Category of Personal Information</span></p>
+          </td>
+          <td class="c17" colspan="1" rowspan="1">
+            <p class="c19"><span class="c24 c14">Disclosure of Personal Information</span></p>
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="c3">
+          <td class="c7" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">Identifiers, such as your contact details</span></p>
+          </td>
+          <td class="c17" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">We disclose this information to our affiliates, vendors and service
+                providers, law enforcement, and parties involved in Transactions.</span></p>
+          </td>
+        </tr>
+        <tr class="c3">
+          <td class="c7" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">Commercial Information, such as your transaction history</span></p>
+          </td>
+          <td class="c17" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">We disclose this information to our affiliates, vendors and service
+                providers, law enforcement, and parties involved in Transactions.</span></p>
+          </td>
+        </tr>
+        <tr class="c3">
+          <td class="c7" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">Network Activity Information, such as Content and how you interact with our
+                Services</span></p>
+          </td>
+          <td class="c17" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">We disclose this information to our affiliates, vendors and service
+                providers, law enforcement, and parties involved in Transactions.</span></p>
+          </td>
+        </tr>
+        <tr class="c3">
+          <td class="c7" colspan="1" rowspan="1">
+            <p class="c18"><span class="c9 c13">Geolocation Data</span></p>
+          </td>
+          <td class="c17" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">We disclose this information to our affiliates, vendors and service
+                providers, law enforcement, and parties involved in Transactions.</span></p>
+          </td>
+        </tr>
+        <tr class="c3">
+          <td class="c7" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">Your account login credentials (Sensitive Personal Information)</span></p>
+          </td>
+          <td class="c17" colspan="1" rowspan="1">
+            <p class="c18"><span class="c13 c9">We disclose this information to our affiliates, vendors and service
+                providers, law enforcement, and parties involved in Transactions.</span></p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="c8 c39"><span class="c6">To the extent provided for by law and subject to applicable exceptions, California
+        residents have the following privacy rights in relation to their Personal Information:</span></p>
+    <ul class="c16 lst-kix_list_3-0 start">
+      <li class="c12 c25 li-bullet-0"><span class="c6">The right to know information about our processing of your Personal
+          Information, including the specific pieces of Personal Information that we have collected from you;</span></li>
+      <li class="c12 c25 li-bullet-0"><span class="c6">The right to request deletion of your Personal Information;</span>
+      </li>
+      <li class="c12 c25 li-bullet-0"><span class="c6">The right to correct your Personal Information; and</span></li>
+      <li class="c12 c25 li-bullet-0"><span class="c6">The right to be free from discrimination relating to the exercise
+          of any of your privacy rights.</span></li>
+    </ul>
+    <p class="c12 c8"><span class="c6">We don&rsquo;t sell or share Personal Information as defined by the California
+        Consumer Privacy Act, as amended by the California Privacy Rights Act. We also don&rsquo;t process sensitive
+        personal information for the purposes of inferring characteristics about a consumer.</span></p>
+    <p class="c12 c8"><span class="c14">Exercising Your Rights</span><span class="c6">. California residents can exercise
+        their CCPA privacy rights by sending their request to <span class="c32 c9"><a class="c27" href="mailto:info@convergentresearch.org">info@convergentresearch.org</a></span>.</span></p>
+    <p class="c12 c8"><span class="c14">Verification</span><span class="c6">. In order to protect your Personal
+        Information from unauthorized access, change, or deletion, we may require you to verify your credentials before
+        you can submit a request to know, correct, or delete Personal Information. If you do not have an account with us,
+        or if we suspect fraudulent or malicious activity, we may ask you to provide additional Personal Information and
+        proof of residency for verification. If we cannot verify your identity, we will not provide, correct, or delete
+        your Personal Information.</span></p>
+    <p class="c8 c12"><span class="c14">Authorized Agents</span><span class="c6">. you may submit a rights request through
+        an authorized agent. If you do so, the agent must present signed written permission to act on your behalf and you
+        may also be required to independently verify your identity and submit proof of your residency with us. Authorized
+        agent requests can be submitted to <span class="c32 c9"><a class="c27" href="mailto:info@convergentresearch.org">info@convergentresearch.org</a></span>.</span></p>
+    <h3 class="c2" id="h.m77r65n7qj0n"><span class="c11">7. DATA TRANSFERS</span></h3>
+    <p class="c20"><span class="c6">We may transfer your personal information to recipients in other countries that have
+        different data protection laws. When we do so, we will protect that information as described in this Privacy
+        Notice and will comply with applicable legal requirements, providing adequate protection for the transfer.</span>
+    </p>
+    <p class="c20"><span class="c6">If we transfer personal information from the EEA, UK or Switzerland to a country that
+        has not been recognized by the European Commission as providing an adequate level of data protection, we will use
+        appropriate contractual terms with the recipients to safeguard the information. Further information about our data
+        transfer safeguards may be obtained by contacting us as indicated in the &ldquo;How To Contact Us&rdquo; section
+        below.</span></p>
+    <h3 class="c2" id="h.4d34og8"><span class="c11">8. RETENTION OF PERSONAL INFORMATION </span></h3>
+    <p class="c20"><span class="c6">We will retain your personal information for the duration of our relationship, plus a
+        reasonable period to comply with the applicable statute of limitation periods and records retention requirements
+        under applicable laws, or during the pendency of any legal claims or lawful requests or investigations.</span></p>
+    <p class="c20"><span class="c6">We may also anonymize or de-identify your Personal Information (so that it can no
+        longer be associated with you) for research or statistical purposes, as described above, in which case we may use
+        this information indefinitely without further notice to you.</span></p>
+    <h3 class="c2" id="h.2s8eyo1"><span class="c11">9. HOW WE PROTECT PERSONAL INFORMATION</span></h3>
+    <p class="c20"><span class="c6">We implement commercially reasonable technical, administrative, and organizational
+        measures to protect Personal Information both online and offline from loss, misuse, and unauthorized access,
+        disclosure, alteration, or destruction. However, no Internet or email transmission is ever fully secure or error
+        free. In particular, email sent to or from us may not be secure. Therefore, you should take special care in
+        deciding what information you send to us via the Service or email. In addition, we are not responsible for
+        circumvention of any privacy settings or security measures contained on the Service, or third party
+        websites.</span></p>
+    <h3 class="c2" id="h.17dp8vu"><span class="c11">10. CHILDREN&rsquo;S PRIVACY</span></h3>
+    <p class="c20"><span class="c6">The Site and Services are intended for individuals at least 18 years of age. We do not
+        knowingly collect personal information online from children under the age of 13.</span></p>
+    <h3 class="c2" id="h.3rdcrjn"><span class="c11">11. OTHER ONLINE SERVICES AND THIRD-PARTY FEATURES</span></h3>
+    <p class="c20"><span class="c6">For your convenience and information, we may provide links to other online services,
+        and may include third-party features such as apps, tools, communication platforms or communities, widgets and
+        plugins. The privacy practices of the relevant third parties, including details on the information they may
+        collect about you, is subject to the privacy statements of these parties, which we strongly suggest you review.
+        These third-party services or features are not owned or controlled by us and we are not responsible for their
+        information practices.</span></p>
+    <h3 class="c2" id="h.26in1rg"><span class="c11">12. UPDATES TO OUR PRIVACY NOTICE</span></h3>
+    <p class="c20"><span class="c6">This Privacy Notice may be updated periodically for clarity or to reflect changes in
+        law or our practices. We indicate at the top of this Privacy Notice when it was most recently updated. We
+        encourage you to check this page frequently to review any changes. If we make changes, we will notify you via the
+        change log below. In some cases, we may provide additional notice such as a statement on our homepage or an email.
+        Your further use of the Site or Services after a change to our Privacy Notice will be subject to the updated
+        notice.</span></p>
+    <h3 class="c2" id="h.lnxbz9"><span class="c11">13. HOW TO CONTACT US</span></h3>
+    <p class="c20"><span class="c6">We are responsible for processing personal information as described in this Privacy
+        Notice.</span></p>
+    <p class="c20"><span class="c6">If you have any questions, requests or comments about this Privacy Notice or to
+        exercise your rights, please email us at <span class="c32 c9"><a class="c27" href="mailto:info@convergentresearch.org">info@convergentresearch.org</a></span>.
+        You also may write to: 160 Alewife Brook Pkwy #1212, Cambridge, MA 02138-1121, Attn: Privacy.</span></p>
+  </div>
+</template>
+
+<style lang="css" scoped>
+ul {
+  list-style-type: none
+}
+
+ul>li:before {
+  content: "\0025cf   "
+}
+
+ul.lst-kix_list_12-1>li:before {
+  content: "\0025cb   "
+}
+
+li.li-bullet-0:before {
+  margin-left: -18pt;
+  white-space: nowrap;
+  display: inline-block;
+  min-width: 18pt
+}
+
+table td,
+table th {
+  padding: 0
+}
+
+.c17 {
+  border-right-style: solid;
+  padding: 5pt 11pt 5pt 5pt;
+  border-bottom-color: #000000;
+  border-top-width: 1pt;
+  border-right-width: 1pt;
+  border-left-color: #000000;
+  vertical-align: top;
+  border-right-color: #000000;
+  border-left-width: 1pt;
+  border-top-style: solid;
+  border-left-style: solid;
+  border-bottom-width: 1pt;
+  width: 60%; /*274.8pt;*/
+  border-top-color: #000000;
+  border-bottom-style: solid
+}
+
+.c7 {
+  border-right-style: solid;
+  padding: 5pt 11pt 5pt 5pt;
+  border-bottom-color: #000000;
+  border-top-width: 1pt;
+  border-right-width: 1pt;
+  border-left-color: #000000;
+  vertical-align: top;
+  border-right-color: #000000;
+  border-left-width: 1pt;
+  border-top-style: solid;
+  border-left-style: solid;
+  border-bottom-width: 1pt;
+  width: 40%; /*193.2pt;*/
+  border-top-color: #000000;
+  border-bottom-style: solid
+}
+
+.c5 {
+  margin-left: 36pt;
+  padding-top: 0pt;
+  padding-left: 0pt;
+  padding-bottom: 10pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c1 {
+  margin-left: 36pt;
+  padding-top: 0pt;
+  padding-left: 0pt;
+  padding-bottom: 6pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c15 {
+  color: #000000;
+  font-weight: 400;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-family: "Arial";
+  font-style: normal
+}
+
+.c2 {
+  padding-top: 16pt;
+  padding-bottom: 10pt;
+  line-height: 1.1500000000000001;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c6 {
+  color: #000000;
+  font-weight: 400;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-family: "Open Sans", sans-serif;
+  font-style: normal
+}
+
+.c38 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: justify;
+  height: 11pt
+}
+
+.c11 {
+  color: #434343;
+  font-weight: 700;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 14pt;
+  font-family: "Open Sans", sans-serif;
+  font-style: normal
+}
+
+.c36 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.2666666666666666;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c21 {
+  padding-top: 16pt;
+  padding-bottom: 4pt;
+  line-height: 1.1500000000000001;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c4 {
+  color: #000000;
+  font-weight: 400;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-family: "Open Sans", sans-serif;
+  font-style: italic
+}
+
+.c37 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.1500000000000001;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: center
+}
+
+.c28 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c33 {
+  padding-top: 16pt;
+  padding-bottom: 10pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c41 {
+  padding-top: 0pt;
+  padding-bottom: 10pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: justify
+}
+
+.c30 {
+  padding-top: 0pt;
+  padding-bottom: 6pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c20 {
+  padding-top: 0pt;
+  padding-bottom: 10pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c18 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c19 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: center
+}
+
+.c29 {
+  padding-top: 12pt;
+  padding-bottom: 10pt;
+  line-height: 1.1500000000000001;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c12 {
+  padding-top: 0pt;
+  padding-bottom: 10pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c39 {
+  padding-top: 10pt;
+  padding-bottom: 10pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c22 {
+  color: #434343;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 14pt;
+  font-style: normal
+}
+
+.c13 {
+  color: #000000;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 10pt;
+  font-style: normal
+}
+
+.c24 {
+  color: #000000;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-style: normal
+}
+
+.c35 {
+  color: #000000;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 16pt;
+  font-style: normal
+}
+
+.c32 {
+  -webkit-text-decoration-skip: none;
+  color: #1155cc;
+  text-decoration: underline;
+  text-decoration-skip-ink: none
+}
+
+.c23 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  margin-right: auto
+}
+
+.c0 {
+  background-color: #ffffff;
+  font-family: "Open Sans", sans-serif;
+  font-weight: 400
+}
+
+.c14 {
+  font-weight: 700;
+  font-family: "Open Sans", sans-serif
+}
+
+.c31 {
+  font-size: 11pt;
+  color: #000000
+}
+
+.c26 {
+  padding: 72pt 72pt 72pt 72pt
+}
+
+.c16 {
+  padding: 0;
+  margin: 0
+}
+
+.c40 {
+  margin-left: 72pt;
+  padding-left: 0pt
+}
+
+.c27 {
+  color: inherit;
+  text-decoration: inherit
+}
+
+.c25 {
+  margin-left: 36pt;
+  padding-left: 0pt
+}
+
+.c9 {
+  font-weight: 400;
+  font-family: "Open Sans", sans-serif
+}
+
+.c34 {
+  height: 32.5pt
+}
+
+.c10 {
+  font-style: italic
+}
+
+.c3 {
+  height: 48.2pt
+}
+
+li {
+  font-size: 11pt;
+  font-family: "Arial", sans-serif;
+}
+
+p {
+  margin: 0;
+  font-size: 11pt;
+  font-family: "Arial", sans-serif;
+}
+
+h2 {
+  padding-top: 18pt;
+  font-size: 16pt;
+  padding-bottom: 6pt;
+  font-family: "Arial", sans-serif;
+  line-height: 1.1500000000000001;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+h3 {
+  padding-top: 16pt;
+  color: #434343;
+  font-size: 14pt;
+  padding-bottom: 4pt;
+  font-family: "Arial", sans-serif;
+  line-height: 1.1500000000000001;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+</style>

--- a/site/pages/policies/terms.vue
+++ b/site/pages/policies/terms.vue
@@ -1,0 +1,614 @@
+<!-- Adapted from an external resource -->
+
+<template>
+  <div class="card c20 doc-content">
+    <div>
+      <h2 class="c22" id="h.1uempjw8ivb1"><span class="c2 c13">Terms of Use</span></h2>
+    </div>
+    <p class="c19"><span class="c5 c21">Last modified: August 7, 2024</span></p>
+    <p class="c10 c24"><span class="c3"></span></p>
+    <p class="c11"><span class="c3">Thank you for visiting our website!</span></p>
+    <p class="c11"><span class="c5">These terms of use (&ldquo;</span><span class="c2">Terms</span><span
+        class="c5">&rdquo;</span><span class="c5">) apply when you use the products and services of Convergent Research,
+        Inc. or our parent, subsidiaries, or affiliates, (collectively, &ldquo;</span><span class="c2">we</span><span
+        class="c5">&rdquo;, &ldquo;</span><span class="c2">us</span><span class="c5">&rdquo;, &ldquo;</span><span
+        class="c2">our</span><span class="c5">&rdquo;), including application programming interfaces, associated software,
+        tools, developer services, data and documentation, content, events, or activities (collectively,
+        &ldquo;</span><span class="c2">Services</span><span class="c3">&rdquo;). These Terms set forth a legally binding
+        agreement between you and us and, by accessing and using our Services or otherwise interacting with us in
+        connection therewith, you:</span></p>
+    <ol class="c15 lst-kix_nn1mhkfspez5-0 start" start="1">
+      <li class="c11 c4 li-bullet-0"><span class="c5">agree to these Terms personally and on behalf of any company or
+          other legal entity (&ldquo;</span><span class="c2">organization</span><span class="c3">&rdquo;) that you
+          represent when using the services, and</span></li>
+      <li class="c11 c4 li-bullet-0"><span class="c3">represent and warrant that you have the right, authority, and
+          capacity to enter into these Terms and to bind your organization (if applicable) to these Terms. </span></li>
+    </ol>
+    <p class="c11"><span class="c3">If you do not agree to these terms, you are not permitted to access or use the
+        Services.</span></p>
+    <p class="c11"><span class="c2">ARBITRATION NOTICE: THESE TERMS CONTAIN A BINDING ARBITRATION AGREEMENT INCLUDING A
+        WAIVER OF ANY RIGHT TO PARTICIPATE IN A CLASS ACTION LAWSUIT OR CLASS-WIDE ARBITRATION. PLEASE SEE THE
+      </span><span class="c2">ARBITRATION AGREEMENT AND CLASS ACTION WAIVER</span><span class="c2">&nbsp;SECTION BELOW FOR
+        ADDITIONAL DETAILS.</span><span class="c3">&nbsp;</span></p>
+    <h4 class="c9" id="h.65cpcvo6fks0"><span class="c1">1. &nbsp;Who We Are</span></h4>
+    <p class="c0"><span class="c5">Convergent Research is an incubator that brings together top talent from academia,
+        industry, and startups to build a new model for innovative R&amp;D. We identify high-impact scientific or
+        technical research and development opportunities, ultimately defining and launching these projects as Focused
+        Research Organizations. Lean FRO, LLC is a Convergent Research Focused Research Organization focused on enabling
+        mathematicians and other users to work seamlessly with, and have their work augmented by, automated theorem
+        proving and verification software.</span></p>
+    <h4 class="c9" id="h.h24c5hy4rvt2"><span class="c1">2. &nbsp;Privacy Notice</span></h4>
+    <p class="c0"><span class="c5">Please view our </span>
+        <span class="c8 c5"><NuxtLink class="c17" to="/policies/privacy">Privacy Policy</NuxtLink></span><span class="c3">,
+        which explains how we collect and use personal information is incorporated into these Terms. </span></p>
+    <h4 class="c9" id="h.ivzlo9o3kpiv"><span class="c1">3. &nbsp;Modifications</span></h4>
+    <p class="c0"><span class="c3">We reserve the right to modify and update these Terms, as well as any aspect of the
+        Services, at any time in our sole discretion. We will notify you via the Services if we make any material changes.
+        Your continued access to or use of the Services will constitute your acceptance of any modifications or
+        updates.</span></p>
+    <p class="c0 c10"><span class="c3"></span></p>
+    <h4 class="c9" id="h.pe7l67ay1hgx"><span class="c1">4. &nbsp;Registration and Access</span></h4>
+    <p class="c0"><span class="c5">You must be</span><span class="c3">&nbsp;at least 18 years of age (or the age of
+        majority in the jurisdiction in which you reside) to use the Services. The Services are not intended for anyone
+        under 18. If you use the Services on behalf of another person or entity, you must have the authority to accept the
+        Terms on their behalf. You must provide accurate and complete information to register for an account. You may not
+        make your access credentials or account available to others outside your organization, and you are responsible for
+        all activities that occur using your credentials.</span></p>
+    <h4 class="c9" id="h.no6yb25ngqi8"><span class="c1">5. &nbsp;Access to the Services</span></h4>
+    <p class="c0"><span class="c3">You may access, and we grant you a non-exclusive right to use, the Services in
+        accordance with these Terms. You will comply with these Terms and all applicable laws when using the Services. We
+        and our affiliates own all rights, title, and interest in and to the Services.</span></p>
+    <p class="c0"><span class="c3">We may suspend or terminate your access to the Services for any reason or no reason,
+        without prior notice to you, including but not limited to if you violate these Terms; if we suspect that you are
+        using the Services in an unauthorized manner; or if you act in any way that would discredit or harm our
+        reputation. </span></p>
+    <h4 class="c9" id="h.93ndfihmwcmw"><span class="c1">6. &nbsp;Our Content</span></h4>
+    <p class="c0"><span class="c5">The Services, and in particular all information, content, images, logos, trademarks,
+        graphics, software, and other materials we make available in connection with the Services (collectively, the
+        &ldquo;</span><span class="c2">Content</span><span class="c3">&rdquo;) are the sole property of us or our
+        affiliates or their licensors and are protected by copyright, trademark, and other laws, both in the United States
+        and in other countries.</span></p>
+    <p class="c0"><span class="c3">The Content is provided for information purposes only and is not to be relied upon as
+        professional opinion or advice. The Content is not guaranteed to be accurate, complete, reliable, current or
+        error-free; use at your own risk.</span></p>
+    <p class="c0"><span class="c5">You are granted a non-exclusive, non-transferable, revocable license to access and use
+        the Content for personal, non-commercial purposes only. Additionally, we may publish Content from time-to-time
+        under a Creative Commons or similar license. Except as expressly permitted by us in connection with such
+        publication, you may not reproduce, modify, republish, distribute, resell, broadcast, reverse-engineer, create
+        derivative works from or otherwise exploit in any manner, in whole or in part, the Content. All rights not
+        expressly granted by us are reserved by us, our affiliates and their licensors. </span></p>
+    <h4 class="c9" id="h.274mdos50ig6"><span class="c1">7. &nbsp;Other Services and Features</span></h4>
+    <p class="c0"><span class="c3">For your convenience and information, the Services may provide links to other services
+        and features, including apps, tools, widgets, activities and plugins, which may be operated by entities not
+        affiliated with us. We make no representations or warranties regarding any such service or feature. If you choose
+        to access any link to other services or features, you understand that you are connecting directly to that service
+        or feature and will be subject to any terms of use, policies and privacy practices of the party that operates the
+        service or feature.</span></p>
+    <h4 class="c9" id="h.64a6mmnfvqpu"><span class="c1">8. &nbsp;Your Materials</span></h4>
+    <p class="c0"><span class="c5">All content, responses, answers, comments, ideas, proposals, photos and other
+        information and materials that you post or submit to us or the Services (collectively, &ldquo;</span><span
+        class="c2">Materials</span><span class="c3">&rdquo;) shall be handled as follows. While we may not review or
+        monitor submissions of Materials, we reserve the right to block, refuse, delete, remove or edit, in whole or in
+        part, any Materials that violate these Terms or that are otherwise objectionable, as determined by us in our sole
+        discretion. We assume no liability in connection with any use of your Materials, including any errors or omissions
+        contained therein, or for any loss or damage incurred as a result of any such use. You are solely responsible and
+        assume all risks associated with any Materials you submit or that are submitted on your behalf.</span></p>
+    <p class="c0"><span class="c3">You grant to us a nonexclusive, royalty-free, perpetual, worldwide, irrevocable,
+        sublicensable and transferable license to use, host, store, reproduce, modify, publish, adapt, translate, edit,
+        create derivative works from, publicly display and distribute any Materials you submit in connection with the
+        Services in any and all media now known or hereinafter devised. You hereby waive any moral rights you may have in
+        the Materials. By posting Materials on the Services, or otherwise providing Materials to us, you represent and
+        warrant that you own or have the necessary rights and permissions to provide such Materials to us, and to
+        authorize us to use such Materials in the manner contemplated by these Terms.</span></p>
+    <p class="c0"><span class="c3">We will be entitled to use Materials for any purpose in connection with the provision
+        and promotion of the Services, without further notice or compensation to you or any other person. For the
+        avoidance of doubt, we will not be liable to you or any other person for the use or exploitation of any ideas
+        (including, without limitation, product ideas, designs, or business models) derived from your Materials and will
+        not incur any liability as a result of any similarities to the Materials that may appear in any future products or
+        services of us or our affiliates.</span></p>
+    <p class="c0"><span class="c5">If you provide or disclose to us any suggestions, ideas, or feedback (collectively,
+        &ldquo;</span><span class="c2">Feedback</span><span class="c3">&rdquo;) with respect to the Services or other
+        potential products and services, you hereby grant to us and our affiliates, a worldwide, perpetual, irrevocable,
+        transferable, nonexclusive, royalty-free license, with the right to sublicense, to use and exploit the Feedback
+        for any purpose.</span></p>
+    <p class="c0"><span class="c3">You shall not submit to us anything that you deem confidential, and under no
+        circumstances will we be required to treat any Materials or portion thereof as confidential. If you would like to
+        submit any confidential Materials to us, please contact us to discuss the possibility of entering into an
+        appropriate confidentiality agreement.</span></p>
+    <h4 class="c9" id="h.8uwdxjgaetek"><span class="c1">9. &nbsp;Acceptable Use Policy</span></h4>
+    <p class="c0"><span class="c3">Your Materials must adhere to all guidelines, rules, standards, and other requirements
+        set forth by us.</span></p>
+    <p class="c0"><span class="c3">You agree that you will not post or submit any Materials or use Services in a manner
+        that violates any posted code of conduct or that otherwise: (1) is obscene, inappropriate, threatening, harassing,
+        abusive, false, inaccurate, deceptive, libelous, defamatory, vulgar, pornographic, invasive of privacy or is
+        otherwise injurious to third parties; (2) constitutes a criminal offense, gives rise to civil liability, or
+        otherwise violates any local, state, national, or international law; (3) contains computer viruses, malware, bots,
+        worms, Trojan horses or other harmful, disruptive, or destructive materials that limit the functionality of any
+        computer software, hardware, or telecommunications equipment; (4) includes unsolicited advertisements, promotional
+        materials, spam, junk mail, pyramid schemes or other forms of solicitation; (5) impersonates another person or
+        entity or falsely states or misrepresents your affiliation with a person or entity; (6) attempts to or disguises
+        the origin of any Materials; (7) implies our endorsement of your content; (8) restricts or interferes with any
+        other person&rsquo;s ability to use or enjoy the Services, as determined by us in our sole discretion; (9) tampers
+        with postings, registration information, submissions or content of other people; (10) uses any robot, spider,
+        scraper or other automated means or interface not provided by us to access the Services; (11) extracts data or
+        gathers or uses information available through the Services through any means not intentionally made available or
+        provided for through the Services; (12) infringes or alleges to be infringing upon a third-party&#39;s
+        intellectual property rights, including any patent, trademark, trade secret, copyright, right of publicity, or
+        other proprietary rights of any party, including, without limitation, any content that is the subject of any
+        third-party claim of infringement; (13) violates contractual or fiduciary relationships; or (14) violates these
+        Terms, or uses the Services in any manner that is inconsistent with the purposes or objectives of the Services, as
+        determined in good faith by us.</span></p>
+    <p class="c0"><span class="c3">We reserve the right to suspend or terminate your access to the Services and seek other
+        legal or equitable remedies, upon becoming aware of any violation of this Acceptable Use Policy by you. </span>
+    </p>
+    <h4 class="c9" id="h.3wf1xhmzuuod"><span class="c1">10. &nbsp;Copyright</span></h4>
+    <h5 class="c6" id="h.fqx4318clrxo"><span class="c14">Reporting Claims of Copyright Infringement</span></h5>
+    <p class="c0"><span class="c5">We take claims of copyright infringement seriously. We will respond to notices of
+        alleged copyright infringement that comply with applicable law. If you believe any materials accessible on or from
+        the Services infringe your copyright, you may request removal of those materials (or access to them) from the
+        Services by submitting written notification to our copyright agent designated below. In accordance with the Online
+        Copyright Infringement Liability Limitation Act of the Digital Millennium Copyright Act (17 U.S.C. &sect; 512)
+        (&ldquo;</span><span class="c2">DMCA</span><span class="c5">&rdquo;), the written notice (the &ldquo;</span><span
+        class="c2">DMCA Notice</span><span class="c3">&rdquo;) must include substantially the following:</span></p>
+    <ul class="c15 lst-kix_fsm2mb75e3fi-0 start">
+      <li class="c0 c4 li-bullet-0"><span class="c3">Your physical or electronic signature.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">Identification of the copyrighted work you believe to have been
+          infringed or, if the claim involves multiple works accessible through the Services, a representative list of
+          such works.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">Identification of the material you believe to be infringing in a
+          sufficiently precise manner to allow us to locate that material.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">Adequate information by which we can contact you (including your
+          name, postal address, telephone number, and, if available, email address).</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">A statement that you have a good faith belief that use of the
+          copyrighted material is not authorized by the copyright owner, its agent, or the law.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">A statement that the information in the written notice is
+          accurate.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">A statement, under penalty of perjury, that you are authorized to act
+          on behalf of the copyright owner.</span></li>
+    </ul>
+    <p class="c0"><span class="c3">If you fail to comply with all of the requirements of Section 512(c)(3) of the DMCA,
+        your DMCA Notice may not be effective.</span></p>
+    <p class="c0"><span class="c3">Please be aware that if you knowingly materially misrepresent that material or activity
+        accessible through the Services is infringing your copyright, you may be held liable for damages (including costs
+        and attorneys&#39; fees) under Section 512(f) of the DMCA.</span></p>
+    <h5 class="c6" id="h.awr8j9bk41qi"><span class="c14">Counter Notification Procedures</span></h5>
+    <p class="c0"><span class="c5">If you believe that material you posted through the Services was removed or access to
+        it was disabled by mistake or misidentification, you may file a counter notification with us (a
+        &ldquo;</span><span class="c2">Counter Notice</span><span class="c3">&rdquo;) by submitting written notification
+        to our copyright agent designated below. Pursuant to the DMCA, the Counter Notice must include substantially the
+        following:</span></p>
+    <ul class="c15 lst-kix_lpc2ttu5xt9v-0 start">
+      <li class="c0 c4 li-bullet-0"><span class="c3">Your physical or electronic signature.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">An identification of the material that has been removed or to which
+          access has been disabled and the location at which the material appeared before it was removed or access
+          disabled.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">Adequate information by which we can contact you (including your
+          name, postal address, telephone number, and, if available, email address).</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">A statement under penalty of perjury by you that you have a good
+          faith belief that the material identified above was removed or disabled as a result of a mistake or
+          misidentification of the material to be removed or disabled.</span></li>
+      <li class="c0 c4 li-bullet-0"><span class="c3">A statement that you will consent to the jurisdiction of the Federal
+          District Court for the judicial district in which your address is located (or if you reside outside the United
+          States for any judicial district in which the Services may be found) and that you will accept service from the
+          person (or an agent of that person) who provided the DMCA Notice at issue.</span></li>
+    </ul>
+    <p class="c0"><span class="c3">The DMCA allows us to restore the removed content if the party filing the original DMCA
+        Notice does not file a court action against you within ten business days of receiving the copy of your Counter
+        Notice.</span></p>
+    <p class="c0"><span class="c3">Please be aware that if you knowingly materially misrepresent that material or activity
+        on the Services was removed or disabled by mistake or misidentification, you may be held liable for damages
+        (including costs and attorneys&#39; fees) under Section 512(f) of the DMCA.</span></p>
+    <h5 class="c6" id="h.3995t1voat6w"><span class="c14">DMCA Agent</span></h5>
+    <p class="c0"><span class="c3">Our designated copyright agent to receive DMCA Notices and Counter Notices is:</span>
+    </p>
+    <p class="c7"><span class="c3">Copyright Manager</span></p>
+    <p class="c7"><span class="c3">Lean FRO, LLC</span></p>
+    <p class="c7"><span class="c3">160 Alewife Brook Pkwy #1212</span></p>
+    <p class="c7"><span class="c3">Cambridge, MA 02138-1121</span></p>
+    <p class="c7"><span class="c5">Email: </span><span class="c8 c5"><a class="c17"
+          href="mailto:legal@convergentresearch.org">legal@convergentresearch.org</a></span><span class="c3">&nbsp;</span>
+    </p>
+    <h5 class="c6" id="h.1z6fob24oma3"><span class="c14">Repeat Infringers</span></h5>
+    <p class="c0"><span class="c3">It is our policy in appropriate circumstances to disable and/or terminate the accounts
+        of users who are repeat infringers.</span></p>
+    <h4 class="c9" id="h.qzq8l1jwqn6r"><span class="c1">11. &nbsp;Term and Termination</span></h4>
+    <p class="c0"><span class="c3">These Terms take effect when you first use the Services and remain in effect until
+        terminated. You may terminate these Terms at any time for any reason by discontinuing the use of the Services and
+        Content. We may terminate these Terms for any reason by providing you at least 30 days&rsquo; advance notice. We
+        may terminate these Terms immediately upon notice to you if you materially breach the sections on Registration and
+        Access, Acceptable Use Policy, Copyright, Binding Arbitration and Class Action Waiver, or General Terms; if there
+        are changes in relationships with third party technology providers outside of our control; or to comply with law
+        or government requests. The sections of these Terms which by their nature should survive termination or expiration
+        will survive.</span></p>
+    <h4 class="c9" id="h.hoqlko6ywtls"><span class="c1">12. &nbsp;Warranty Disclaimer</span></h4>
+    <p class="c0"><span class="c3">THE SERVICES AND THE CONTENT ARE PROVIDED ON AN &quot;AS IS&quot; AND &ldquo;AS
+        AVAILABLE&rdquo; BASIS. WE MAKE NO REPRESENTATIONS OR WARRANTIES OF ANY KIND THAT THE SERVICES OR CONTENT WILL
+        MEET YOUR REQUIREMENTS, THE SERVICES WILL BE TIMELY, SECURE, ERROR FREE OR UNINTERRUPTED, THE SERVICES WILL BE
+        FREE OF ANY MALWARE OR OTHER HARMFUL CODE, OR THE CONTENT OR RESULTS OBTAINED FROM THE SERVICES OR FROM US WILL BE
+        ACCURATE, COMPLETE, OR RELIABLE. </span></p>
+    <p class="c0"><span class="c3">WE AND OUR AFFILIATES AND LICENSORS DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+        STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT
+        AND FITNESS FOR A PARTICULAR PURPOSE. </span></p>
+    <p class="c0"><span class="c3">CERTAIN JURISDICTIONS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES AND, ACCORDINGLY,
+        THE LIMITATIONS IN THIS SECTION MAY NOT APPLY TO YOU. IF YOU ARE A CONSUMER, ANY STATUTORY RIGHTS THAT CANNOT BE
+        WAIVED BY YOU ARE UNAFFECTED BY THIS SECTION. </span></p>
+    <h4 class="c9" id="h.5yta1n8qmj4e"><span class="c1">13. &nbsp;Limitation of Liability</span></h4>
+    <p class="c0"><span class="c3">TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL WE OR OUR
+        AFFILIATES OR LICENSORS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INCIDENTAL, INDIRECT, EXEMPLARY,
+        PUNITIVE, SPECIAL, OR CONSEQUENTIAL DAMAGES, OR LOST REVENUES, PROFITS CAPITAL OR OVERHEAD, ARISING OUT OF OR
+        RELATED TO YOUR ACCESS TO OR USE OF THE SERVICES, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING
+        NEGLIGENCE), DELICT OR ANY OTHER LEGAL THEORY AND WHETHER OR NOT WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGES. </span></p>
+    <p class="c0"><span class="c3">BECAUSE SOME JURISDICTIONS DO NOT ALLOW FOR THE EXCLUSION OF DAMAGES, OUR LIABILITY IN
+        SUCH JURISDICTIONS SHALL BE LIMITED TO THE MAXIMUM EXTENT PERMITTED BY THE LAWS OF SUCH JURISDICTION. </span></p>
+    <h4 class="c9" id="h.go9ceoftibj6"><span class="c1">14. &nbsp;Indemnity</span></h4>
+    <p class="c0"><span class="c3">You agree to indemnify, defend and hold harmless us and our affiliates, successors and
+        assigns, and each of their respective trustees, officers, directors, employees, agents, suppliers and
+        representatives, from and against all claims, liabilities, actions, suits, proceedings, assessments, judgments,
+        decrees, losses, expenses, damages, settlement funds, fines, penalties and associated costs and expenses,
+        including reasonable attorneys&rsquo; fees, arising out of or related to (1) your use or misuse of the Services,
+        including any Content; (2) your breach of these Terms; (3) Materials submitted or provided to us; or (4) any use
+        of your Materials and/or our exercise of any rights granted to us, including without limitation claims based on
+        rights of privacy, rights of publicity, false light, defamation, copyright, patent and/or trademark infringement
+        relating to your Materials. We reserve the right to assume the exclusive defense and control of any matter that is
+        subject to indemnification under this section, in which event you agree to cooperate with any reasonable requests
+        assisting our defense of such matter. </span></p>
+    <h4 class="c9" id="h.cqz4fgm169no"><span class="c1">15. &nbsp;Release of Claims</span></h4>
+    <p class="c0"><span class="c3">You hereby release us and our affiliates, successors and assigns, and each of their
+        respective trustees, officers, directors, employees, agents, suppliers and representatives from and against the
+        full amount of all claims, liabilities, actions, suits, proceedings, assessments, judgments, decrees, losses,
+        fees, damages, settlement funds, and associated costs and expenses including attorney&rsquo;s fees arising from or
+        in connection with your use of the Services, any use of your Materials, and/or our exercise of any rights granted
+        to us, including without limitation claims based on rights of privacy, rights of publicity, false light,
+        defamation, copyright, patent and/or trademark infringement relating to Materials and claims for injury, loss or
+        damage of any kind resulting from your use of any Content.</span></p>
+    <h4 class="c9" id="h.dv17asrkwjwx"><span class="c1">16. &nbsp;Governing Law</span></h4>
+    <p class="c0"><span class="c3">All questions concerning the construction, validity, enforcement and interpretation of
+        these Terms shall be governed by and construed in accordance with the domestic laws of the State of California,
+        without giving effect to any choice of law or conflict of law.</span></p>
+    <h4 class="c9" id="h.p1umasd3s9m3"><span class="c1">17. &nbsp;Binding Arbitration and Class Action Waiver</span></h4>
+    <p class="c0"><span class="c3">To the fullest extent permitted by law, you and we agree to arbitrate any controversy,
+        claim or dispute arising out of or in any way related to your use of the Services, including but not limited to
+        claims based on contract, tort, negligence, statutory or regulatory provisions. EACH PARTY IS GIVING UP ITS RIGHT
+        TO SUE IN COURT AND TO HAVE ANY CONTROVERSY, CLAIM OR DISPUTE HEARD BY A JUDGE OR JURY.</span></p>
+    <p class="c0"><span class="c3">YOU AND WE EXPRESSLY AGREE TO ARBITRATE ANY CONTROVERSY, CLAIM OR DISPUTE ARISING OUT
+        OF OR IN ANY WAY RELATED TO YOUR USE OF THE SERVICES. THIS AGREEMENT TO ARBITRATE ALSO APPLIES TO THRESHOLD
+        ARBITRABILITY ISSUES, INCLUDING ISSUES RELATED TO WHETHER THIS AGREEMENT TO ARBITRATE IS UNCONSCIONABLE OR
+        ILLUSORY AND ANY DEFENSE TO ARBITRATION. YOU ALSO AGREE THAT ANY ARBITRATION MAY ONLY BE BROUGHT IN YOUR AND OUR
+        INDIVIDUAL CAPACITIES, NOT AS A CLASS, PURPORTED CLASS OR REPRESENTATIVE ACTION. THE ARBITRATOR MAY NOT
+        CONSOLIDATE MORE THAN ONE INDIVIDUAL OR ENTITY&rsquo;S CLAIMS, AND MAY NOT OTHERWISE PRESIDE OVER ANY FORM OF A
+        REPRESENTATIVE OR CLASS PROCEEDING.</span></p>
+    <p class="c0"><span class="c3">The mutual promise by you and us to arbitrate any and all disputes, and to do so on an
+        individual basis, rather than to litigate before the courts or other bodies, provides the mutual consideration for
+        this agreement to arbitrate.</span></p>
+    <p class="c0"><span class="c3">Either party may exercise the right to arbitrate by providing the other party with
+        written notice of any and all claims forming the basis of such right in sufficient detail to inform the other
+        party of the substance of such claims. In no event shall the request for arbitration be made after the date when
+        institution of legal or equitable proceedings based on such claims would be barred by the applicable statute of
+        limitations.</span></p>
+    <p class="c0"><span class="c5">Unless you and we otherwise agree, the arbitration will be conducted in the county
+        where you reside by a single neutral arbitrator and in accordance with the then-current rules for resolution of
+        disputes of the American Arbitration Association (AAA) (available online at
+        </span><span class="c5 c8"><a class="c17" href="http://www.adr.org/">www.adr.org</a></span><span class="c3">&nbsp;or
+        by calling 1-800-778-7879). The parties are entitled to representation by an attorney or other
+        representative of their choosing. The parties agree to abide by and perform any award rendered by the arbitrator.
+        The arbitrator shall issue the award in writing and therein state the essential findings and conclusions on which
+        the award is based. Judgment on the award may be entered in any court having jurisdiction thereof. Payment of all
+        filing, administration and arbitrator fees will be governed by the AAA&#39;s rules.</span></p>
+    <p class="c0"><span class="c3">If this arbitration clause is held unenforceable or arbitration is for any other reason
+        not available, any disputes under this Agreement shall be heard in a court of competent jurisdiction in San
+        Francisco, California.</span></p>
+    <h4 class="c9" id="h.mvqqscxvxxj6"><span class="c1">18. &nbsp;General Terms</span></h4>
+    <p class="c0"><span class="c5">You are an independent contractor and nothing contained herein shall create an
+        employment or agency relationship, a joint venture, or a partnership. No failure to enforce these Terms shall
+        constitute a waiver of any provision contained herein. To the extent any portion of these Terms is determined to
+        be unenforceable by a court of competent jurisdiction, such </span><span class="c5">portion</span><span
+        class="c5">&nbsp;will be modified solely to the extent necessary to cause such </span><span
+        class="c5">portion</span><span class="c3">&nbsp;to be enforceable, and these Terms, as modified, will remain in
+        full force and effect. This is the entire agreement between you and us relating to the subject matter herein.
+      </span></p>
+    <h4 class="c9" id="h.9ijuy1641qoi"><span class="c2">19. &nbsp;Electronic Communications</span></h4>
+    <p class="c0"><span class="c3">These Terms and any other documentation, agreements, notices, or communications between
+        you and us are provided to you electronically. You consent to receive these electronic communications and you
+        agree that all agreements, notices, disclosures and other communications that we provide to you electronically,
+        via email and on the Services, satisfy any legal requirement that such communications be in writing. Please print
+        or otherwise save a copy of all documentation, agreements, notices, and other communications for your reference.
+      </span></p>
+    <h4 class="c9" id="h.vl7u2eh5nqm1"><span class="c1">20. &nbsp;How To Contact Us</span></h4>
+    <p class="c0"><span class="c3">If you have any questions about these Terms or would like to report violations of our
+        policies, please email us at <span class="c8 c5"><a class="c17" href="mailto:info@convergentresearch.org">info@convergentresearch.org</a></span>.
+        You also may write to: 160 Alewife Brook Pkwy #1212, Cambridge, MA 02138-1121, Attn: Terms of Use.</span></p>
+    <p class="c19 c10"><span class="c3"></span></p>
+    <div>
+      <p class="c10 c12"><span class="c18"></span></p>
+    </div>
+  </div>
+</template>
+
+<style lang="css" scoped>
+ul, ol {
+  list-style-type: none
+}
+
+ul>li:before {
+  content: "\0025cf   "
+}
+
+ol.lst-kix_nn1mhkfspez5-0.start {
+  counter-reset: lst-ctn-kix_nn1mhkfspez5-0 0
+}
+
+.lst-kix_nn1mhkfspez5-0>li {
+  counter-increment: lst-ctn-kix_nn1mhkfspez5-0
+}
+
+.lst-kix_nn1mhkfspez5-0>li:before {
+  content: "" counter(lst-ctn-kix_nn1mhkfspez5-0, decimal) ". "
+}
+
+li.li-bullet-0:before {
+  margin-left: -18pt;
+  white-space: nowrap;
+  display: inline-block;
+  min-width: 18pt
+}
+
+ol {
+  margin: 0;
+  padding: 0
+}
+
+table td,
+table th {
+  padding: 0
+}
+
+.c1 {
+  color: #666666;
+  font-weight: 700;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 12pt;
+  font-family: "Open Sans", sans-serif;
+  font-style: normal
+}
+
+.c6 {
+  padding-top: 12pt;
+  padding-bottom: 10pt;
+  line-height: 1.15;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c7 {
+  margin-left: 36pt;
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c3 {
+  color: #000000;
+  font-weight: 400;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-family: "Open Sans", sans-serif;
+  font-style: normal
+}
+
+.c18 {
+  color: #000000;
+  font-weight: 400;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-family: "Arial", sans-serif;
+  font-style: normal
+}
+
+.c22 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.15;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: center
+}
+
+.c9 {
+  padding-top: 14pt;
+  padding-bottom: 10pt;
+  line-height: 1.15;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c14 {
+  color: #666666;
+  font-weight: 400;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-family: "Arial", sans-serif;
+  font-style: normal
+}
+
+.c24 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.15;
+  orphans: 2;
+  widows: 2;
+  text-align: justify
+}
+
+.c0 {
+  padding-top: 0pt;
+  padding-bottom: 10pt;
+  line-height: 1.15;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c12 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.0;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c19 {
+  padding-top: 0pt;
+  padding-bottom: 0pt;
+  line-height: 1.15;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+.c11 {
+  padding-top: 0pt;
+  padding-bottom: 10pt;
+  line-height: 1.15;
+  orphans: 2;
+  widows: 2;
+  text-align: justify
+}
+
+.c21 {
+  color: #000000;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-style: italic
+}
+
+.c16 {
+  color: #666666;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 12pt;
+  font-style: normal
+}
+
+.c13 {
+  color: #000000;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 16pt;
+  font-style: normal
+}
+
+.c23 {
+  color: #000000;
+  text-decoration: none;
+  vertical-align: baseline;
+  font-size: 11pt;
+  font-style: normal
+}
+
+.c8 {
+  -webkit-text-decoration-skip: none;
+  color: #1155cc;
+  text-decoration: underline;
+  text-decoration-skip-ink: none
+}
+
+.c20 {
+  padding: 72pt 72pt 45pt 72pt
+}
+
+.c2 {
+  font-weight: 700;
+  font-family: "Open Sans", sans-serif
+}
+
+.c5 {
+  font-weight: 400;
+  font-family: "Open Sans", sans-serif
+}
+
+.c4 {
+  margin-left: 36pt;
+  padding-left: 0pt
+}
+
+.c17 {
+  color: inherit;
+  text-decoration: inherit
+}
+
+.c15 {
+  padding: 0;
+  margin: 0
+}
+
+.c10 {
+  height: 11pt
+}
+
+li {
+  color: #000000;
+  font-size: 11pt;
+  font-family: "Arial", sans-serif;
+}
+
+p {
+  margin: 0;
+  color: #000000;
+  font-size: 11pt;
+  font-family: "Arial", sans-serif;
+}
+
+h2 {
+  padding-top: 18pt;
+  color: #000000;
+  font-size: 16pt;
+  padding-bottom: 6pt;
+  font-family: "Arial", sans-serif;
+  line-height: 1.15;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+h4 {
+  padding-top: 14pt;
+  color: #666666;
+  font-size: 12pt;
+  padding-bottom: 4pt;
+  font-family: "Arial", sans-serif;
+  line-height: 1.15;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+
+h5 {
+  padding-top: 12pt;
+  color: #666666;
+  font-size: 11pt;
+  padding-bottom: 4pt;
+  font-family: "Arial", sans-serif;
+  line-height: 1.15;
+  page-break-after: avoid;
+  orphans: 2;
+  widows: 2;
+  text-align: left
+}
+</style>


### PR DESCRIPTION
Adds the FRO's Terms of Use and Privacy Policy to the website, which now falls under these terms. 

Also reorganizes the footer links to accommodate these additional items.