### PR TITLE
feat: richer dependencies

### DIFF
--- a/scripts/utils/core.py
+++ b/scripts/utils/core.py
@@ -3,9 +3,11 @@ import subprocess
 import itertools
 import hashlib
 from datetime import datetime, timezone
-from typing import TypeVar, Iterable, Iterator, Literal, overload
+from typing import Any, Mapping, TypeVar, Iterable, Iterator, Literal, overload
 
 T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
 
 def configure_logging(verbosity: int):
   if verbosity == 0:
@@ -32,6 +34,22 @@ def fmt_bytes(num: float):
 
 def ifnone(value: T | None, default: T) -> T:
   return default if value is None else value
+
+def filter_type(type: type[T], value: Any, default: V = None) -> T | V:
+  return value if isinstance(value, type) else default
+
+def get_type(mapping: Mapping[K, Any], key: K, type: type[T], default: V = None) -> T | V:
+  return filter_type(type, mapping.get(key, default), default)
+
+def get_type_values(mapping: Mapping[K, Any], key: K, type: type[T]) -> Iterable[T]:
+  for e in get_type(mapping, key, Iterable, []):
+    if isinstance(e, type):
+      yield e
+
+def filter_ws(value: str | None):
+  if value is not None:
+    value = value.strip() or None
+  return value
 
 # adapted from https://stackoverflow.com/a/44873382
 def filehash(path: str) -> str:

--- a/scripts/utils/manifest.py
+++ b/scripts/utils/manifest.py
@@ -19,10 +19,10 @@ class DepBase(TypedDict):
   url : str | None
 
 class Dependent(DepBase):
-  pass
+  fullName: str
 
-class Dependency(DepBase):
-  pass
+class Dependency(DepBase, total=False):
+  fullName: str
 
 def mk_dependency(contents: Any, type: str | None = None) -> Dependency | None:
   if not isinstance(contents, dict): return None

--- a/scripts/utils/manifest.py
+++ b/scripts/utils/manifest.py
@@ -1,31 +1,44 @@
 import re
 from typing import TypedDict, Any, NoReturn, overload
 from functools import total_ordering
+from utils.core import *
 
 # assumes escaped names are simple (which is fine for now)
 FRENCH_QUOTE_PATTERN = re.compile('[«»]')
 def unescape_name(name: str) -> str:
   return FRENCH_QUOTE_PATTERN.sub('', name)
 
-class Dependency(TypedDict):
+class DepBase(TypedDict):
   type: str
   name: str
-  scope: str
+  scope: str | None
   version: str
+  transitive: bool | None
   rev: str | None
+  inputRev: str | None
+  url : str | None
+
+class Dependent(DepBase):
+  pass
+
+class Dependency(DepBase):
+  pass
 
 def mk_dependency(contents: Any, type: str | None = None) -> Dependency | None:
   if not isinstance(contents, dict): return None
-  type = type or contents.get('type', None)
+  type = type or get_type(contents, 'type', str)
   if type is None: return None
-  name = contents.get('name', None)
+  name = get_type(contents, 'name', str)
   if name is None: return None
   return {
     'type': type,
     'name': unescape_name(name),
-    'scope': contents.get('scope', ''),
-    'version': contents.get('version', '0.0.0'),
-    'rev': contents.get('rev', None),
+    'scope': filter_ws(get_type(contents, 'scope', str)),
+    'version': get_type(contents, 'version', str, '0.0.0'),
+    'transitive': get_type(contents, 'inherited', bool),
+    'rev': get_type(contents, 'rev', str),
+    'inputRev': get_type(contents, 'inputRev', str),
+    'url': get_type(contents, 'url', str),
   }
 
 VERSION_PATTERN = re.compile(r'(\d+)\.(\d+)\.(\d+)(?:-(.*))?')

--- a/scripts/utils/package.py
+++ b/scripts/utils/package.py
@@ -87,7 +87,8 @@ TestbedResults = list[TestbedResult]
 
 #`1.0.0: Reservoir 1.0
 # 1.1.0: Added `archiveHash`
-INDEX_SCHEMA_VERSION_STR = '1.1.0'
+# 1.2.0: More Dependency data (`transitive``, `inputRev`, `url``)
+INDEX_SCHEMA_VERSION_STR = '1.2.0'
 INDEX_SCHEMA_VERSION = Version(INDEX_SCHEMA_VERSION_STR)
 
 class PackageMetadata(TypedDict):
@@ -182,6 +183,12 @@ def git_src(pkg: PackageMetadata) -> GitSrc | None:
   for src in pkg['sources']:
     if src.get('type', None) == 'git':
       return cast(GitSrc, src)
+  return None
+
+def git_url(pkg: PackageMetadata) -> str | None:
+  for src in pkg['sources']:
+    if src.get('type', None) == 'git':
+      return cast(GitSrc, src)['gitUrl']
   return None
 
 def github_src(pkg: PackageMetadata) -> GitHubSrc | None:

--- a/scripts/utils/package.py
+++ b/scripts/utils/package.py
@@ -116,7 +116,7 @@ class Package(PackageMetadata):
   relpath: str | None
 
 class SerialPackage(PackageMetadata):
-  dependents: list[Dependency]
+  dependents: list[Dependent]
   versions: list[PackageVersionMetadata]
   builds: list[Build]
 

--- a/scripts/utils/repo.py
+++ b/scripts/utils/repo.py
@@ -173,11 +173,6 @@ def query_licenses(url: str = SPDX_DATA_URL):
     licenses[license['licenseId']] = license
   return licenses
 
-def filter_ws(value: str | None):
-  if value is not None:
-    value = value.strip() or None
-  return value
-
 def filter_license(license: str | None) -> str | None:
   if filter_ws(license) is None: return None
   if license in ['NONE', 'NOASSERTION']: return None

--- a/site/components/DepItem.vue
+++ b/site/components/DepItem.vue
@@ -8,7 +8,7 @@ import ReservoirIcon from '~/public/favicon.svg?component'
 
 const props = defineProps<{package: Package, dep: PackageDep, upstream: boolean}>()
 const dep = computed(() => props.dep)
-const depPkg = computed(() => props.dep.scope ? findPkg(dep.value.scope, dep.value.name) : undefined)
+const depPkg = computed(() => dep.value.scope ? findPkg(dep.value.scope, dep.value.name) : undefined)
 const ver = computed(() => {
   const pkg = props.upstream ? depPkg.value : props.package
   return pkg?.versions.find(ver => ver.revision == dep.value.rev)

--- a/site/components/DepItem.vue
+++ b/site/components/DepItem.vue
@@ -5,15 +5,18 @@ import UnknownIcon from '~icons/mdi/help'
 import TagIcon from '~icons/mdi/tag'
 import AtIcon from '~icons/mdi/at'
 import ReservoirIcon from '~/public/favicon.svg?component'
+import { Tippy } from 'vue-tippy'
 
 const props = defineProps<{package: Package, dep: PackageDep, upstream: boolean}>()
 const dep = computed(() => props.dep)
-const depPkg = computed(() => dep.value.scope ? findPkg(dep.value.scope, dep.value.name) : undefined)
+const depPkg = computed(() => dep.value.fullName ? getPkg(dep.value.fullName) : undefined)
 const ver = computed(() => {
   const pkg = props.upstream ? depPkg.value : props.package
   return pkg?.versions.find(ver => ver.revision == dep.value.rev)
 })
-const depName = computed(() => props.upstream ? dep.value.name : (depPkg.value ? depPkg.value.fullName : dep.value.name))
+const depName = computed(() => {
+  return props.upstream ? dep.value.name : (depPkg.value ? depPkg.value.fullName : dep.value.name)
+})
 const verId = computed(() => {
   if (dep.value.version != '0.0.0') return dep.value.version
   if (ver.value?.tag) return ver.value.tag
@@ -25,23 +28,38 @@ const verId = computed(() => {
 <template>
   <li class="dep-item card">
     <div v-if="upstream" class="dep-type">
-      <ReservoirIcon v-if="depPkg" class="icon"/>
-      <GitIcon v-else-if="dep.type == 'git'" class="icon"/>
-      <FolderIcon v-else-if="dep.type == 'path'" class="icon"/>
-      <UnknownIcon v-else class="icon"/>
+      <Tippy>
+        <ReservoirIcon v-if="dep.scope && depPkg" class="icon"/>
+        <GitIcon v-else-if="dep.type == 'git'" class="icon"/>
+        <FolderIcon v-else-if="dep.type == 'path'" class="icon"/>
+        <UnknownIcon v-else class="icon"/>
+        <template #content>
+          <div class="dep-tooltip">
+            <span v-if="dep.scope">Registry dependency.</span>
+            <span v-else-if="dep.type == 'git'">Git dependency.</span>
+            <span v-else-if="dep.type == 'path'">Local path dependency.</span>
+            <span v-else>(BUG) Unknown dependency..</span>
+            <br/>
+            <span v-if="depPkg">Found on Reservoir.</span>
+            <span v-else>Not found on Reservoir.</span>
+          </div>
+        </template>
+      </Tippy>
     </div>
     <div class="dep-info">
       <h3 class="dep-header">
-        <NuxtLink class="dep-name dep-link" v-if="depPkg" :to="pkgLink(depPkg)">{{depName}}</NuxtLink>
-        <div class="dep-name" v-else>{{depName}}</div>
-        <div class="dep-version">
+        <NuxtLink class="dep-name dep-link" v-if="depPkg" :to="pkgLink(depPkg)">
+          <span>{{depName}}</span>
+        </NuxtLink>
+        <span class="dep-name" v-else>{{depName}}</span>
+        <span class="dep-version">
           <AtIcon v-if="upstream" class="dep-at icon"/>
           <span v-else class="dep-at">uses</span>
-          <div class="version-id">
+          <span class="version-id">
             <TagIcon v-if="dep.version == '0.0.0' && ver?.tag" class="icon"/>
             <code>{{verId}}</code>
-          </div>
-        </div>
+          </span>
+        </span>
       </h3>
       <div v-if="depPkg && depPkg.description" class="description">
         {{ depPkg.description  }}
@@ -57,6 +75,7 @@ li.dep-item {
   align-items: center;
   position: relative;
   padding: 1em;
+  z-index: 0;
 
   &:has(.dep-link):hover {
     background-color: var(--medium-color);
@@ -70,6 +89,8 @@ li.dep-item {
   .dep-type {
     margin-left: 0.5em;
     margin-right: 1.2em;
+    position: relative;
+    z-index: 1;
 
     .icon {
       width: 1.8em;
@@ -88,7 +109,7 @@ li.dep-item {
   }
 
   .dep-name {
-    display: block;
+    display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
     text-wrap: nowrap;
@@ -96,13 +117,13 @@ li.dep-item {
   }
 
   .dep-version {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     font-size: 0.8em;
     color: var(--dark-color);
 
     .version-id {
-      display: flex;
+      display: inline-flex;
       align-items: center;
       padding: 0.2em 0.3em;
       border-radius: 5px;
@@ -143,5 +164,9 @@ li.dep-item {
   .description {
     margin-top: 0.5em;
   }
+}
+
+.dep-tooltip {
+  text-align: center
 }
 </style>

--- a/site/components/SortedList.vue
+++ b/site/components/SortedList.vue
@@ -37,7 +37,7 @@ const sortLink = function(key: string) {
       <slot name="header" :first="first" :last="last" :total="numItems">
         <div class="list-info">
           <span class="displaying">Displaying </span>
-          <strong>{{ first+1 }}-{{ last }}</strong>
+          <strong>{{ last > 0 ? first+1 : 0 }}-{{ last }}</strong>
           <span> of </span>
           <strong>{{ numItems }}</strong>
           <span class="total-label"><slot name="total-label"/></span>

--- a/site/pages/@[owner]/[name]/dependencies.vue
+++ b/site/pages/@[owner]/[name]/dependencies.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 const props = defineProps<{package: Package, version: PackageVer | null | undefined}>()
+const transitive = ref(false)
 const deps = computed(() => {
-  const deps = props.version?.dependencies ?? []
-  return deps.map((dep, idx) => Object.assign({}, dep, {idx: idx}))
+  let deps = props.version?.dependencies ?? []
+  if (!transitive.value) {
+    deps = deps.filter(dep => !dep.transitive)
+  }
+  return  deps.map((dep, idx) => Object.assign({}, dep, {idx: idx}))
 })
 const sortOptions: NonEmptyArray<SortOption<typeof deps.value[number]>> = [
   {label: "Require Order", key: "require", sort: (a, b) => a.idx - b.idx},
@@ -13,8 +17,14 @@ const sortOptions: NonEmptyArray<SortOption<typeof deps.value[number]>> = [
 <template>
   <div class="dependencies-tab">
     <SortedList :items="deps" :itemKey="dep => dep.name" :sortOptions="sortOptions">
-      <template #total-label>
-        dependencies of <strong>{{ package.name }}</strong>
+      <template #header>
+        <div class="dep-list-info">
+          <input id="dep-transitive" v-model="transitive" type="checkbox">
+          <label for="dep-transitive">
+            <span class="short-label">Transitive</span>
+            <span class="long-label">Include transitive dependencies</span>
+          </label>
+        </div>
       </template>
       <template #item="{item}">
         <DepItem :upstream="true" :package="package" :dep="item"/>
@@ -22,3 +32,21 @@ const sortOptions: NonEmptyArray<SortOption<typeof deps.value[number]>> = [
     </SortedList>
   </div>
 </template>
+
+<style lang="scss">
+.dep-list-info {
+  display: flex;
+
+  label {
+    margin-left: 0.5em;
+  }
+
+  @media only screen and (max-width: 50em) {
+    .long-label { display: none; }
+  }
+
+  @media only screen and (min-width: 40em) {
+    .short-label { display: none; }
+  }
+}
+</style>

--- a/site/pages/@[owner]/[name]/dependents.vue
+++ b/site/pages/@[owner]/[name]/dependents.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 const props = defineProps<{package: Package}>()
 const deps = computed(() => props.package.dependents)
-const sortOptions: NonEmptyArray<SortOption<PackageDep>> = [
+const sortOptions: NonEmptyArray<SortOption<PackageDependent>> = [
   {label: "Package Name", key: "name", sort: (a, b) => a.name.localeCompare(b.name)},
   {label: "Package Owner", key: "owner", sort(a, b) {
-    return a.scope.localeCompare(b.scope) || a.name.localeCompare(b.name)
+    return a.fullName.localeCompare(b.fullName)
   }},
 ]
 </script>
 
 <template>
   <div class="dependents-tab">
-    <SortedList :items="deps" :itemKey="dep => `${dep.scope}/${dep.name}`" :sortOptions="sortOptions">
+    <SortedList :items="deps" :itemKey="dep => dep.fullName" :sortOptions="sortOptions">
       <template #total-label>
         packages depending on <strong class="nowrap">{{ package.fullName }}</strong>
       </template>

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -36,12 +36,18 @@ export interface PackageDep {
   type: string
   name: string
   scope: string | null
+  fullName?: string | null
   version: string
   transitive?: boolean | null
   rev: string | null
   inputRev?: string | null
   url?: string | null
 }
+
+export interface PackageDependent extends PackageDep {
+  fullName: string
+}
+
 
 export interface PackageVer {
   version: string
@@ -68,7 +74,7 @@ export interface Package {
   stars: number
   sources: Source[]
   versions: PackageVer[]
-  dependents: PackageDep[]
+  dependents: PackageDependent[]
   builds: Build[]
 }
 
@@ -94,6 +100,10 @@ export function findPkg(owner: string, name: string) {
     return p.owner.toLowerCase() === owner.toLowerCase() &&
       p.name.toLowerCase() == name.toLowerCase()
   })
+}
+
+export function getPkg(fullName: string) {
+  return packages.find(p => p.fullName == fullName)
 }
 
 export function rawPkgLink(owner: string, name: string) {

--- a/site/utils/manifest.ts
+++ b/site/utils/manifest.ts
@@ -35,9 +35,12 @@ export interface Build {
 export interface PackageDep {
   type: string
   name: string
-  scope: string
+  scope: string | null
   version: string
+  transitive?: boolean | null
   rev: string | null
+  inputRev?: string | null
+  url?: string | null
 }
 
 export interface PackageVer {


### PR DESCRIPTION
Reservoir now stores additional information about dependencies. This is used to link plain Git dependencies to Reservoir packages by their Git URL. A package's dependencies tab also has a new toggle to switch between a list of direct and transitive dependencies. The default is now just direct.

Closes #49.